### PR TITLE
move regenerator-runtime and core-os to devDependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,16 +1,16 @@
-# coverage
-# npm-debug.log
-# .vscode
-# .jest-test-results.json
-# .git
-# CNAME
-# dist
-# pids
-# *.pid
-# *.seed
-# *.pid.lock
-# .DS_Store
-# lib-cov
-# node_modules
-# .babel-cache
-# docs
+coverage
+npm-debug.log
+.vscode
+.jest-test-results.json
+.git
+CNAME
+dist
+pids
+*.pid
+*.seed
+*.pid.lock
+.DS_Store
+lib-cov
+node_modules
+.babel-cache
+docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN apk --no-cache add git
 # Create the .npmrc file
 RUN echo ${NPMRC} | base64 -d > .npmrc
 
+# install npm
+RUN apk add --update nodejs nodejs-npm
+
 # Creating tar of productions dependencies
 RUN npm i && cp -rp ./node_modules /tmp/node_modules
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,11 @@ RUN echo ${NPMRC} | base64 -d > .npmrc
 # install npm
 RUN apk add --update nodejs nodejs-npm
 
-# Creating tar of production dependencies
-RUN npm i && cp -rp ./node_modules /tmp/node_modules
-
 # Copying application code
 COPY . /app
+
+# Install dependencies
+RUN npm ci
 
 # Install CodeClimate Test Coverage Reporter
 RUN apk --no-cache add curl  

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,8 @@ WORKDIR /app
 # Install git required for codecov and chromatic cli's
 RUN apk --no-cache add git
 
-# Create the .npmrc file
-RUN echo ${NPMRC} | base64 -d > .npmrc
-
-# install npm
-RUN apk add --update nodejs nodejs-npm
+# # install npm
+# RUN apk add --update nodejs nodejs-npm
 
 # Install CodeClimate Test Coverage Reporter
 RUN apk --no-cache add curl  
@@ -21,18 +18,7 @@ COPY . /app
 # Install dependencies
 RUN npm ci
 
-#FROM node:10.15.0-alpine AS runner
-
 # Expose Storybook port
 EXPOSE 6006
-
-# Adding production dependencies to image
-# COPY --from=builder /tmp/node_modules /app/node_modules
-
-# Copy Apps (Git and CodeCov)
-# COPY --from=builder /tmp/ /usr/bin/
-
-# Copying application code
-# COPY . /app
 
 CMD npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN echo ${NPMRC} | base64 -d > .npmrc
 # install npm
 RUN apk add --update nodejs nodejs-npm
 
-# Creating tar of productions dependencies
+# Creating tar of production dependencies
 RUN npm i && cp -rp ./node_modules /tmp/node_modules
 
 # Copying application code

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM node:10.15.0-alpine AS builder
 
 WORKDIR /app
 
-COPY package.json /app
-
 # Install git required for codecov and chromatic cli's
 RUN apk --no-cache add git
 
@@ -13,21 +11,24 @@ RUN echo ${NPMRC} | base64 -d > .npmrc
 # install npm
 RUN apk add --update nodejs nodejs-npm
 
-# Copying application code
-COPY . /app
+# Install CodeClimate Test Coverage Reporter
+RUN apk --no-cache add curl  
+RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > "/usr/bin/cc-test-reporter" && chmod +x "/usr/bin/cc-test-reporter" && cp -p /usr/bin/cc-test-reporter /tmp/cc-test-reporter
+
+# Install app dependencies
+COPY package.json /app
+COPY package-lock.json /app
 
 # Install dependencies
 RUN npm ci
 
-# Install CodeClimate Test Coverage Reporter
-RUN apk --no-cache add curl  
-RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > "/usr/bin/cc-test-reporter" && chmod +x "/usr/bin/cc-test-reporter" && cp -p /usr/bin/cc-test-reporter /tmp/cc-test-reporter
+# Copying application code
+COPY . /app
 
 #FROM node:10.15.0-alpine AS runner
 
 # Expose Storybook port
 EXPOSE 6006
-WORKDIR /app
 
 # Adding production dependencies to image
 # COPY --from=builder /tmp/node_modules /app/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest
 COPY . /app
 
 # Install dependencies
-RUN npm ci
+RUN npm -q ci
 
 # Expose Storybook port
 EXPOSE 6006

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,11 @@ RUN apk add --update nodejs nodejs-npm
 RUN apk --no-cache add curl  
 RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > "/usr/bin/cc-test-reporter" && chmod +x "/usr/bin/cc-test-reporter" && cp -p /usr/bin/cc-test-reporter /tmp/cc-test-reporter
 
-# Install app dependencies
-COPY package.json /app
-COPY package-lock.json /app
+# Copying application code
+COPY . /app
 
 # Install dependencies
 RUN npm ci
-
-# Copying application code
-COPY . /app
 
 #FROM node:10.15.0-alpine AS runner
 

--- a/README.md
+++ b/README.md
@@ -233,17 +233,17 @@ $ docker build -t  react-command-palette .
 Then, spin up the container once the build is done:
 ```
 $ docker run -it \
-  -v ${PWD}:/usr/src/app \
-  -v /usr/src/app/node_modules \
-  -p 6006:6006 \
+  -v ${PWD}:/app \
+  -p 6006:6006 \     
+  react-command-palette \
   npm i && npm run dev
 ```
 You only need to run "npm i" the when the container is first created. The devDependencies need to be installed to compile and test the build during development. On subsequent builds run:
 ```
 $ docker run -it \
-  -v ${PWD}:/usr/src/app \
-  -v /usr/src/app/node_modules \
-  -p 6006:6006 \
+  -v ${PWD}:/app \
+  -p 6006:6006 \     
+  react-command-palette \
   npm run dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ $ docker run -it \
   -v ${PWD}:/app \
   -p 6006:6006 \     
   react-command-palette \
-  npm run dev
+  npm start
 ```
 
 Open your browser to http://localhost:6006/ and you should see the app. Try making a change to the command-palette component within your code editor. You should see the app hot-reload. Kill the server once done.

--- a/README.md
+++ b/README.md
@@ -232,19 +232,11 @@ $ docker build -t  react-command-palette .
 
 Then, spin up the container once the build is done:
 ```
-$ docker run -it \
-  -v ${PWD}:/app \
-  -p 6006:6006 \     
-  react-command-palette \
-  npm i && npm run dev
+$ docker run -it -v ${PWD}:/app -p 6006:6006 react-command-palette npm i && npm run dev
 ```
 You only need to run "npm i" the when the container is first created. The devDependencies need to be installed to compile and test the build during development. On subsequent builds run:
 ```
-$ docker run -it \
-  -v ${PWD}:/app \
-  -p 6006:6006 \     
-  react-command-palette \
-  npm start
+$ docker run -it -v ${PWD}:/app -p 6006:6006 react-command-palette npm start
 ```
 
 Open your browser to http://localhost:6006/ and you should see the app. Try making a change to the command-palette component within your code editor. You should see the app hot-reload. Kill the server once done.

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -1,9 +1,14 @@
 version: '1.0'
 steps:
+  GitClone:
+    title: Cloning main repository...
+    type: git-clone
+    repo: '${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}'
+    revision: '${{CF_REVISION}}'
   BuildingDockerImage:
     title: Build Docker Image
     type: build
-    image_name: asabaylus/reactcommandpalette
+    image_name: asabaylus/react-command-palette
     working_directory: ./
     tag: '${{CF_BRANCH_TAG_NORMALIZED}}'
     dockerfile: Dockerfile

--- a/package-lock.json
+++ b/package-lock.json
@@ -10637,7 +10637,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -11102,7 +11103,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -11166,6 +11168,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -11214,13 +11217,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7968,7 +7968,8 @@
     "core-js": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.3.tgz",
-      "integrity": "sha512-PWZ+ZfuaKf178BIAg+CRsljwjIMRV8MY00CbZczkR6Zk5LfkSkjGoaab3+bqRQWVITNZxQB7TFYz+CFcyuamvA=="
+      "integrity": "sha512-PWZ+ZfuaKf178BIAg+CRsljwjIMRV8MY00CbZczkR6Zk5LfkSkjGoaab3+bqRQWVITNZxQB7TFYz+CFcyuamvA==",
+      "dev": true
     },
     "core-js-compat": {
       "version": "3.1.2",
@@ -17821,7 +17822,8 @@
     "regenerator-runtime": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10661,13 +10661,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10684,19 +10686,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10827,7 +10832,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10841,6 +10847,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10857,6 +10864,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -10865,13 +10873,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -10892,6 +10902,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10980,7 +10991,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -10994,6 +11006,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -11131,6 +11144,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10637,8 +10637,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10662,15 +10661,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10687,22 +10684,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10833,8 +10827,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10848,7 +10841,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10865,7 +10857,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -10874,15 +10865,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -10903,7 +10892,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10992,8 +10980,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -11007,7 +10994,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -11103,8 +11089,7 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -11146,7 +11131,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -11168,7 +11152,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -11217,15 +11200,13 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "babelrc-rollup": "^3.0.0",
     "codecov": "^3.5.0",
     "concurrently": "^4.1.0",
+    "core-js": "^3.1.3",
     "cross-env": "^5.2.0",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
@@ -108,6 +109,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-test-renderer": "^16.8.6",
+    "regenerator-runtime": "^0.13.2",
     "rollup": "^1.14.4",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-commonjs": "^10.0.0",
@@ -120,13 +122,11 @@
     "storybook-readme": "^5.0.3"
   },
   "dependencies": {
-    "core-js": "^3.1.3",
     "fast-deep-equal": "^2.0.1",
     "fuzzysort": "^1.1.4",
     "mousetrap": "^1.6.3",
     "react-autosuggest": "^9.4.3",
-    "react-modal": "^3.8.1",
-    "regenerator-runtime": "^0.13.2"
+    "react-modal": "^3.8.1"
   },
   "files": [
     "dist",


### PR DESCRIPTION
These deps were added to support the latest version of storybook and are not dependencies for react-command-palette. Bump core-js to v3. NPM is no longer installed by Alpine so install it in the docker image, see: https://superuser.com/a/1187246