### PR TITLE
automatically accept chromatic changes on master

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -5,6 +5,7 @@ checks:
       threshold: 90
 exclude_patterns:
 - "docs/"
+- "scripts/"
 - "examples/"
 - "src/__mocks__"
 - "dist/"

--- a/scripts/chromatic-build.sh
+++ b/scripts/chromatic-build.sh
@@ -1,0 +1,7 @@
+if [ "$CI_BRANCH" != "master" ];
+then
+  npm run chromatic
+else
+  # We know any changes that make it to master *must* have been approved
+  npm run chromatic --auto-accept-changes
+fi


### PR DESCRIPTION
codeship test commands modified:

```
npm run lint
npm run test
./node_modules/.bin/codecov
cc-test-reporter after-build -d -t lcov coverage/lcov.info --exit-code $? --prefix /home/rof/src/github.com/asabaylus/react-command-palette
npm run prebuild:storybook
./scripts/chromatic-build.sh
```