### PR TITLE
Support multiple hotkeys for toggling palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const commands = [{
 
 * ```placeholder``` a _string_ that contains a short text description which is displayed inside the the input field until the user provides input. Defaults to "Type a command".
 
-* ```hotKeys``` a _string_ that contains a keyboard shortcut for opening/closing the palette. Defaults to "_command+shift+p_". Uses [mousetrap key combos](https://craig.is/killing/mice)  
+* ```hotKeys``` a _string_ or _array of strings_ that contain a keyboard shortcut for opening/closing the palette. Defaults to "_command+shift+p_". Uses [mousetrap key combos](https://craig.is/killing/mice)
 
 * ```defaultInputValue``` a _string_ that determines the value of the text in the input field. By default the defaultInputValue is an empty string.
 

--- a/src/__snapshots__/command-palette.test.js.snap
+++ b/src/__snapshots__/command-palette.test.js.snap
@@ -3486,6 +3486,48 @@ exports[`Command List renders a command 1`] = `
                     class="atom-header"
                   />
                   <div
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    aria-owns="react-autowhatever-1"
+                    class="atom-container"
+                    role="combobox"
+                  >
+                    <input
+                      aria-autocomplete="list"
+                      aria-controls="react-autowhatever-1"
+                      autocomplete="off"
+                      class="atom-input"
+                      placeholder="Type a command"
+                      type="text"
+                      value=""
+                    />
+                    <div
+                      class="atom-suggestionsContainer"
+                      id="react-autowhatever-1"
+                      role="listbox"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ReactModalPortal"
+          >
+            <div
+              class="ReactModal__Overlay ReactModal__Overlay--after-open ReactModal__Overlay--before-close atom-overlay"
+            >
+              <div
+                aria-label="Command Palette"
+                class="ReactModal__Content ReactModal__Content--after-open ReactModal__Content--before-close atom-modal"
+                role="dialog"
+                tabindex="-1"
+              >
+                <div>
+                  <div
+                    class="atom-header"
+                  />
+                  <div
                     aria-expanded="true"
                     aria-haspopup="listbox"
                     aria-owns="react-autowhatever-1"
@@ -7688,6 +7730,48 @@ exports[`Command List renders a command 1`] = `
                             </li>
                           </ul>
                         </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ReactModalPortal"
+              >
+                <div
+                  class="ReactModal__Overlay ReactModal__Overlay--after-open ReactModal__Overlay--before-close atom-overlay"
+                >
+                  <div
+                    aria-label="Command Palette"
+                    class="ReactModal__Content ReactModal__Content--after-open ReactModal__Content--before-close atom-modal"
+                    role="dialog"
+                    tabindex="-1"
+                  >
+                    <div>
+                      <div
+                        class="atom-header"
+                      />
+                      <div
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        aria-owns="react-autowhatever-1"
+                        class="atom-container"
+                        role="combobox"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="react-autowhatever-1"
+                          autocomplete="off"
+                          class="atom-input"
+                          placeholder="Type a command"
+                          type="text"
+                          value=""
+                        />
+                        <div
+                          class="atom-suggestionsContainer"
+                          id="react-autowhatever-1"
+                          role="listbox"
+                        />
                       </div>
                     </div>
                   </div>

--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -212,7 +212,7 @@ class CommandPalette extends React.Component {
     // FIXME: apply "esc" on the modal instead of input
     // so that pressing esc on loading spinner works too
     const { hotKeys } = this.props;
-    Mousetrap(this.commandPaletteInput.input).bind(["esc", hotKeys], () => {
+    Mousetrap(this.commandPaletteInput.input).bind(["esc"].concat(hotKeys), () => {
       this.handleCloseModal();
       return false;
     });
@@ -394,14 +394,18 @@ CommandPalette.propTypes = {
     return null;
   },
 
-  /** placeholder a string that contains a short text description which is displaye
+  /** placeholder a string that contains a short text description which is displayed
    * inside the the input field until the user provides input. Defaults to "Type a
    * command" */
   placeholder: PropTypes.string,
 
-  /** hotKeys a string that contains a keyboard shortcut for opening/closing the palette.
+  /** hotKeys a string or array of strings that contain a keyboard shortcut for
+   * opening/closing the palette.
    * Defaults to "command+shift+p" */
-  hotKeys: PropTypes.string,
+  hotKeys: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.string
+  ]),
 
   /** defaultInputValue a string that determines the value of the text in the input field.
    * By default the defaultInputValue is an empty string. */

--- a/src/command-palette.test.js
+++ b/src/command-palette.test.js
@@ -433,6 +433,32 @@ describe("Opening the palette", () => {
       expect(spyHandleOpenModal).toHaveBeenCalled();
       expect(spyHandleOpenModal.mock.calls).toHaveLength(1);
       expect(commandPalette.state("showModal")).toEqual(true);
+      spyHandleOpenModal.mockClear();
+    });
+
+    it('opens the commandPalette when pressing either "ctrl+shift+p" or "ctrl+k" keys', () => {
+      const spyHandleOpenModal = jest.spyOn(
+        CommandPalette.prototype,
+        "handleOpenModal"
+      );
+      const commandPalette = mount(
+        <CommandPalette hotKeys={["ctrl+shift+p", "ctrl+k"]} commands={mockCommands} />
+      );
+      commandPalette.instance().handleCloseModal();
+      // verify modal is hidden before we try to open it
+      expect(commandPalette.state("showModal")).toBe(false);
+
+      Mousetrap.trigger("ctrl+shift+p");
+      expect(commandPalette.state("showModal")).toEqual(true);
+      commandPalette.instance().handleCloseModal();
+
+      Mousetrap.trigger("ctrl+k");
+      expect(commandPalette.state("showModal")).toEqual(true);
+      commandPalette.instance().handleCloseModal();
+
+      expect(spyHandleOpenModal).toHaveBeenCalled();
+      expect(spyHandleOpenModal.mock.calls).toHaveLength(2);
+      spyHandleOpenModal.mockClear();
     });
   });
 });

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -254,6 +254,9 @@ storiesOf("Command Palette", module)
   .add("with custom hotkeys", () => (
     <CommandPalette commands={commands} hotKeys="/" />
   ))
+  .add("with multiple custom hotkeys", () => (
+    <CommandPalette commands={commands} hotKeys={["/", "command+k"]} />
+  ))
   .add("with custom header", () => (
     <CommandPalette commands={commands} header={sampleHeader()} open />
   ))


### PR DESCRIPTION
The need cropped up to support multiple shortcuts to open and close the command palette. Mousetrap already supports multiple hotkeys by passing it an array argument, so it was a minor change to support it here also.