### PR TITLE
Add onChange query

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -34,6 +34,7 @@
     "no-unused-expressions": [0],
     "no-continue": [0],
     "no-plusplus": [0],
+    "operator-linebreak": [0],
     "func-names": [0],
     "arrow-parens": [0],
     "space-before-function-paren": [0],

--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ const commands = [{
   ```js
     <CommandPalette
       commands={commands}
-      onChange={(value, query) => {
-        alert(`The input value was changed to:\n
-        ${value}\n
+      onChange={(inputValue, userQuery) => {
+        alert(`The input inputVwas changed to:\n
+        ${inputValue}\n
         \n
         The user typed:\n
-        ${query}
+        ${userQuery}
         `);
       }}
     />

--- a/README.md
+++ b/README.md
@@ -84,14 +84,17 @@ const commands = [{
     allowTypo: true, 
     scoreFn: null 
   ```
-* ```onChange``` a function that's called when the input value changes. It returns the current value of the input field.
+* ```onChange``` a function that's called when the input value changes. It returns two values: the current value of the input field followed by the users typed input. The query ignores keyboard navigation and clicks.
 
   ```js
     <CommandPalette
       commands={commands}
-      onChange={value => {
-        alert(`The input value was changed to: \n
-        ${value}
+      onChange={(value, query) => {
+        alert(`The input value was changed to:\n
+        ${value}\n
+        \n
+        The user typed:\n
+        ${query}
         `);
       }}
     />

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,7 +15,8 @@ module.exports = {
   collectCoverageFrom: ["src/*.js"],
   coveragePathIgnorePatterns: [
     "<rootDir>/node_modules",
-    "<rootDir>/src/main.js"
+    "<rootDir>/src/main.js",
+    "<rootDir>/src/test-helpers.js"
   ],
   coverageReporters: ["json", "lcov", "text"]
 };

--- a/src/__snapshots__/command-palette.test.js.snap
+++ b/src/__snapshots__/command-palette.test.js.snap
@@ -2241,9 +2241,6 @@ exports[`Command List renders a command 1`] = `
           />
           <div
             class="ReactModalPortal"
-          />
-          <div
-            class="ReactModalPortal"
           >
             <div
               class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
@@ -3813,6 +3810,555 @@ exports[`Command List renders a command 1`] = `
                       </ul>
                     </div>
                   </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ReactModalPortal"
+          />
+          <div
+            class="ReactModalPortal"
+          >
+            <div
+              class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+            >
+              <div
+                aria-label="Command Palette"
+                class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                role="dialog"
+                tabindex="-1"
+              >
+                <div>
+                  <div
+                    class="atom-header"
+                  />
+                  <div
+                    aria-expanded="true"
+                    aria-haspopup="listbox"
+                    aria-owns="react-autowhatever-1"
+                    class="atom-container atom-containerOpen"
+                    role="combobox"
+                  >
+                    <input
+                      aria-autocomplete="list"
+                      aria-controls="react-autowhatever-1"
+                      autocomplete="off"
+                      class="atom-input atom-inputOpen"
+                      placeholder="Type a command"
+                      type="text"
+                      value="f"
+                    />
+                    <div
+                      class="atom-suggestionsContainer atom-suggestionsContainerOpen"
+                      id="react-autowhatever-1"
+                      role="listbox"
+                    >
+                      <ul
+                        class="atom-suggestionsList"
+                        role="listbox"
+                      >
+                        <li
+                          aria-selected="false"
+                          class="atom-suggestion atom-suggestionFirst"
+                          data-suggestion-index="0"
+                          id="react-autowhatever-1--item-0"
+                          role="option"
+                        >
+                          <div
+                            class="item"
+                          >
+                            <span>
+                              Go o
+                              <b>
+                                f
+                              </b>
+                              fline
+                            </span>
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ReactModalPortal"
+          >
+            <div
+              class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+            >
+              <div
+                aria-label="Command Palette"
+                class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                role="dialog"
+                tabindex="-1"
+              >
+                <div>
+                  <div
+                    class="atom-header"
+                  />
+                  <div
+                    aria-expanded="true"
+                    aria-haspopup="listbox"
+                    aria-owns="react-autowhatever-1"
+                    class="atom-container atom-containerOpen"
+                    role="combobox"
+                  >
+                    <input
+                      aria-autocomplete="list"
+                      aria-controls="react-autowhatever-1"
+                      autocomplete="off"
+                      class="atom-input atom-inputOpen"
+                      placeholder="Type a command"
+                      type="text"
+                      value="foo"
+                    />
+                    <div
+                      class="atom-suggestionsContainer atom-suggestionsContainerOpen"
+                      id="react-autowhatever-1"
+                      role="listbox"
+                    >
+                      <ul
+                        class="atom-suggestionsList"
+                        role="listbox"
+                      >
+                        <li
+                          aria-selected="false"
+                          class="atom-suggestion atom-suggestionFirst"
+                          data-suggestion-index="0"
+                          id="react-autowhatever-1--item-0"
+                          role="option"
+                        >
+                          <div
+                            class="item"
+                          >
+                            <span>
+                              Start All Data Imports
+                            </span>
+                          </div>
+                        </li>
+                        <li
+                          aria-selected="false"
+                          class="atom-suggestion"
+                          data-suggestion-index="1"
+                          id="react-autowhatever-1--item-1"
+                          role="option"
+                        >
+                          <div
+                            class="item"
+                          >
+                            <span>
+                              Stop All Data Imports
+                            </span>
+                          </div>
+                        </li>
+                        <li
+                          aria-selected="false"
+                          class="atom-suggestion"
+                          data-suggestion-index="2"
+                          id="react-autowhatever-1--item-2"
+                          role="option"
+                        >
+                          <div
+                            class="item"
+                          >
+                            <span>
+                              Delete All Tenant
+                            </span>
+                          </div>
+                        </li>
+                        <li
+                          aria-selected="false"
+                          class="atom-suggestion"
+                          data-suggestion-index="3"
+                          id="react-autowhatever-1--item-3"
+                          role="option"
+                        >
+                          <div
+                            class="item"
+                          >
+                            <span>
+                              Go offline
+                            </span>
+                          </div>
+                        </li>
+                        <li
+                          aria-selected="false"
+                          class="atom-suggestion"
+                          data-suggestion-index="4"
+                          id="react-autowhatever-1--item-4"
+                          role="option"
+                        >
+                          <div
+                            class="item"
+                          >
+                            <span>
+                              Go online
+                            </span>
+                          </div>
+                        </li>
+                        <li
+                          aria-selected="false"
+                          class="atom-suggestion"
+                          data-suggestion-index="5"
+                          id="react-autowhatever-1--item-5"
+                          role="option"
+                        >
+                          <div
+                            class="item"
+                          >
+                            <span>
+                              Jump to Tenant
+                            </span>
+                          </div>
+                        </li>
+                        <li
+                          aria-selected="false"
+                          class="atom-suggestion"
+                          data-suggestion-index="6"
+                          id="react-autowhatever-1--item-6"
+                          role="option"
+                        >
+                          <div
+                            class="item"
+                          >
+                            <span>
+                              View Logs 
+                            </span>
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ReactModalPortal"
+          >
+            <div
+              class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+            >
+              <div
+                aria-label="Command Palette"
+                class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                role="dialog"
+                tabindex="-1"
+              >
+                <div>
+                  <div
+                    class="atom-header"
+                  />
+                  <div
+                    aria-expanded="true"
+                    aria-haspopup="listbox"
+                    aria-owns="react-autowhatever-1"
+                    class="atom-container atom-containerOpen"
+                    role="combobox"
+                  >
+                    <input
+                      aria-autocomplete="list"
+                      aria-controls="react-autowhatever-1"
+                      autocomplete="off"
+                      class="atom-input atom-inputOpen"
+                      placeholder="Type a command"
+                      type="text"
+                      value="Start"
+                    />
+                    <div
+                      class="atom-suggestionsContainer atom-suggestionsContainerOpen"
+                      id="react-autowhatever-1"
+                      role="listbox"
+                    >
+                      <ul
+                        class="atom-suggestionsList"
+                        role="listbox"
+                      >
+                        <li
+                          aria-selected="false"
+                          class="atom-suggestion atom-suggestionFirst"
+                          data-suggestion-index="0"
+                          id="react-autowhatever-1--item-0"
+                          role="option"
+                        >
+                          <div
+                            class="item"
+                          >
+                            <span>
+                              <b>
+                                Start
+                              </b>
+                               All Data Imports
+                            </span>
+                          </div>
+                        </li>
+                        <li
+                          aria-selected="false"
+                          class="atom-suggestion"
+                          data-suggestion-index="1"
+                          id="react-autowhatever-1--item-1"
+                          role="option"
+                        >
+                          <div
+                            class="item"
+                          >
+                            <span>
+                              <b>
+                                St
+                              </b>
+                              op 
+                              <b>
+                                A
+                              </b>
+                              ll Data Impo
+                              <b>
+                                rt
+                              </b>
+                              s
+                            </span>
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ReactModalPortal"
+          >
+            <div
+              class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+            >
+              <div
+                aria-label="Command Palette"
+                class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                role="dialog"
+                tabindex="-1"
+              >
+                <div>
+                  <div
+                    class="atom-header"
+                  />
+                  <div
+                    aria-expanded="true"
+                    aria-haspopup="listbox"
+                    aria-owns="react-autowhatever-1"
+                    class="atom-container atom-containerOpen"
+                    role="combobox"
+                  >
+                    <input
+                      aria-autocomplete="list"
+                      aria-controls="react-autowhatever-1"
+                      autocomplete="off"
+                      class="atom-input atom-inputOpen"
+                      placeholder="Type a command"
+                      type="text"
+                      value="Stop All Data Imports"
+                    />
+                    <div
+                      class="atom-suggestionsContainer atom-suggestionsContainerOpen"
+                      id="react-autowhatever-1"
+                      role="listbox"
+                    >
+                      <ul
+                        class="atom-suggestionsList"
+                        role="listbox"
+                      >
+                        <li
+                          aria-selected="false"
+                          class="atom-suggestion atom-suggestionFirst"
+                          data-suggestion-index="0"
+                          id="react-autowhatever-1--item-0"
+                          role="option"
+                        >
+                          <div
+                            class="item"
+                          >
+                            <span>
+                              <b>
+                                Start
+                              </b>
+                               All Data Imports
+                            </span>
+                          </div>
+                        </li>
+                        <li
+                          aria-selected="false"
+                          class="atom-suggestion"
+                          data-suggestion-index="1"
+                          id="react-autowhatever-1--item-1"
+                          role="option"
+                        >
+                          <div
+                            class="item"
+                          >
+                            <span>
+                              <b>
+                                St
+                              </b>
+                              op 
+                              <b>
+                                A
+                              </b>
+                              ll Data Impo
+                              <b>
+                                rt
+                              </b>
+                              s
+                            </span>
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ReactModalPortal"
+          >
+            <div
+              class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+            >
+              <div
+                aria-label="Command Palette"
+                class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                role="dialog"
+                tabindex="-1"
+              >
+                <div>
+                  <div
+                    class="atom-header"
+                  />
+                  <div
+                    aria-expanded="true"
+                    aria-haspopup="listbox"
+                    aria-owns="react-autowhatever-1"
+                    class="atom-container atom-containerOpen"
+                    role="combobox"
+                  >
+                    <input
+                      aria-autocomplete="list"
+                      aria-controls="react-autowhatever-1"
+                      autocomplete="off"
+                      class="atom-input atom-inputOpen"
+                      placeholder="Type a command"
+                      type="text"
+                      value="Start All Data Imports"
+                    />
+                    <div
+                      class="atom-suggestionsContainer atom-suggestionsContainerOpen"
+                      id="react-autowhatever-1"
+                      role="listbox"
+                    >
+                      <ul
+                        class="atom-suggestionsList"
+                        role="listbox"
+                      >
+                        <li
+                          aria-selected="false"
+                          class="atom-suggestion atom-suggestionFirst"
+                          data-suggestion-index="0"
+                          id="react-autowhatever-1--item-0"
+                          role="option"
+                        >
+                          <div
+                            class="item"
+                          >
+                            <span>
+                              <b>
+                                Start
+                              </b>
+                               All Data Imports
+                            </span>
+                          </div>
+                        </li>
+                        <li
+                          aria-selected="false"
+                          class="atom-suggestion"
+                          data-suggestion-index="1"
+                          id="react-autowhatever-1--item-1"
+                          role="option"
+                        >
+                          <div
+                            class="item"
+                          >
+                            <span>
+                              <b>
+                                St
+                              </b>
+                              op 
+                              <b>
+                                A
+                              </b>
+                              ll Data Impo
+                              <b>
+                                rt
+                              </b>
+                              s
+                            </span>
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ReactModalPortal"
+          >
+            <div
+              class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+            >
+              <div
+                aria-label="Command Palette"
+                class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                role="dialog"
+                tabindex="-1"
+              >
+                <div
+                  class="default-spinner atom-spinner modal"
+                  role="status"
+                >
+                  <span
+                    class="sr-only"
+                  >
+                    Loading...
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ReactModalPortal"
+          >
+            <div
+              class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+            >
+              <div
+                aria-label="Command Palette"
+                class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                role="dialog"
+                tabindex="-1"
+              >
+                <div
+                  class="default-spinner atom-spinner modal"
+                  role="status"
+                >
+                  <span
+                    class="sr-only"
+                  >
+                    Loading...
+                  </span>
                 </div>
               </div>
             </div>
@@ -6507,9 +7053,6 @@ exports[`Command List renders a command 1`] = `
               />
               <div
                 class="ReactModalPortal"
-              />
-              <div
-                class="ReactModalPortal"
               >
                 <div
                   class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
@@ -8079,6 +8622,555 @@ exports[`Command List renders a command 1`] = `
                           </ul>
                         </div>
                       </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ReactModalPortal"
+              />
+              <div
+                class="ReactModalPortal"
+              >
+                <div
+                  class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+                >
+                  <div
+                    aria-label="Command Palette"
+                    class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                    role="dialog"
+                    tabindex="-1"
+                  >
+                    <div>
+                      <div
+                        class="atom-header"
+                      />
+                      <div
+                        aria-expanded="true"
+                        aria-haspopup="listbox"
+                        aria-owns="react-autowhatever-1"
+                        class="atom-container atom-containerOpen"
+                        role="combobox"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="react-autowhatever-1"
+                          autocomplete="off"
+                          class="atom-input atom-inputOpen"
+                          placeholder="Type a command"
+                          type="text"
+                          value="f"
+                        />
+                        <div
+                          class="atom-suggestionsContainer atom-suggestionsContainerOpen"
+                          id="react-autowhatever-1"
+                          role="listbox"
+                        >
+                          <ul
+                            class="atom-suggestionsList"
+                            role="listbox"
+                          >
+                            <li
+                              aria-selected="false"
+                              class="atom-suggestion atom-suggestionFirst"
+                              data-suggestion-index="0"
+                              id="react-autowhatever-1--item-0"
+                              role="option"
+                            >
+                              <div
+                                class="item"
+                              >
+                                <span>
+                                  Go o
+                                  <b>
+                                    f
+                                  </b>
+                                  fline
+                                </span>
+                              </div>
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ReactModalPortal"
+              >
+                <div
+                  class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+                >
+                  <div
+                    aria-label="Command Palette"
+                    class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                    role="dialog"
+                    tabindex="-1"
+                  >
+                    <div>
+                      <div
+                        class="atom-header"
+                      />
+                      <div
+                        aria-expanded="true"
+                        aria-haspopup="listbox"
+                        aria-owns="react-autowhatever-1"
+                        class="atom-container atom-containerOpen"
+                        role="combobox"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="react-autowhatever-1"
+                          autocomplete="off"
+                          class="atom-input atom-inputOpen"
+                          placeholder="Type a command"
+                          type="text"
+                          value="foo"
+                        />
+                        <div
+                          class="atom-suggestionsContainer atom-suggestionsContainerOpen"
+                          id="react-autowhatever-1"
+                          role="listbox"
+                        >
+                          <ul
+                            class="atom-suggestionsList"
+                            role="listbox"
+                          >
+                            <li
+                              aria-selected="false"
+                              class="atom-suggestion atom-suggestionFirst"
+                              data-suggestion-index="0"
+                              id="react-autowhatever-1--item-0"
+                              role="option"
+                            >
+                              <div
+                                class="item"
+                              >
+                                <span>
+                                  Start All Data Imports
+                                </span>
+                              </div>
+                            </li>
+                            <li
+                              aria-selected="false"
+                              class="atom-suggestion"
+                              data-suggestion-index="1"
+                              id="react-autowhatever-1--item-1"
+                              role="option"
+                            >
+                              <div
+                                class="item"
+                              >
+                                <span>
+                                  Stop All Data Imports
+                                </span>
+                              </div>
+                            </li>
+                            <li
+                              aria-selected="false"
+                              class="atom-suggestion"
+                              data-suggestion-index="2"
+                              id="react-autowhatever-1--item-2"
+                              role="option"
+                            >
+                              <div
+                                class="item"
+                              >
+                                <span>
+                                  Delete All Tenant
+                                </span>
+                              </div>
+                            </li>
+                            <li
+                              aria-selected="false"
+                              class="atom-suggestion"
+                              data-suggestion-index="3"
+                              id="react-autowhatever-1--item-3"
+                              role="option"
+                            >
+                              <div
+                                class="item"
+                              >
+                                <span>
+                                  Go offline
+                                </span>
+                              </div>
+                            </li>
+                            <li
+                              aria-selected="false"
+                              class="atom-suggestion"
+                              data-suggestion-index="4"
+                              id="react-autowhatever-1--item-4"
+                              role="option"
+                            >
+                              <div
+                                class="item"
+                              >
+                                <span>
+                                  Go online
+                                </span>
+                              </div>
+                            </li>
+                            <li
+                              aria-selected="false"
+                              class="atom-suggestion"
+                              data-suggestion-index="5"
+                              id="react-autowhatever-1--item-5"
+                              role="option"
+                            >
+                              <div
+                                class="item"
+                              >
+                                <span>
+                                  Jump to Tenant
+                                </span>
+                              </div>
+                            </li>
+                            <li
+                              aria-selected="false"
+                              class="atom-suggestion"
+                              data-suggestion-index="6"
+                              id="react-autowhatever-1--item-6"
+                              role="option"
+                            >
+                              <div
+                                class="item"
+                              >
+                                <span>
+                                  View Logs 
+                                </span>
+                              </div>
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ReactModalPortal"
+              >
+                <div
+                  class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+                >
+                  <div
+                    aria-label="Command Palette"
+                    class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                    role="dialog"
+                    tabindex="-1"
+                  >
+                    <div>
+                      <div
+                        class="atom-header"
+                      />
+                      <div
+                        aria-expanded="true"
+                        aria-haspopup="listbox"
+                        aria-owns="react-autowhatever-1"
+                        class="atom-container atom-containerOpen"
+                        role="combobox"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="react-autowhatever-1"
+                          autocomplete="off"
+                          class="atom-input atom-inputOpen"
+                          placeholder="Type a command"
+                          type="text"
+                          value="Start"
+                        />
+                        <div
+                          class="atom-suggestionsContainer atom-suggestionsContainerOpen"
+                          id="react-autowhatever-1"
+                          role="listbox"
+                        >
+                          <ul
+                            class="atom-suggestionsList"
+                            role="listbox"
+                          >
+                            <li
+                              aria-selected="false"
+                              class="atom-suggestion atom-suggestionFirst"
+                              data-suggestion-index="0"
+                              id="react-autowhatever-1--item-0"
+                              role="option"
+                            >
+                              <div
+                                class="item"
+                              >
+                                <span>
+                                  <b>
+                                    Start
+                                  </b>
+                                   All Data Imports
+                                </span>
+                              </div>
+                            </li>
+                            <li
+                              aria-selected="false"
+                              class="atom-suggestion"
+                              data-suggestion-index="1"
+                              id="react-autowhatever-1--item-1"
+                              role="option"
+                            >
+                              <div
+                                class="item"
+                              >
+                                <span>
+                                  <b>
+                                    St
+                                  </b>
+                                  op 
+                                  <b>
+                                    A
+                                  </b>
+                                  ll Data Impo
+                                  <b>
+                                    rt
+                                  </b>
+                                  s
+                                </span>
+                              </div>
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ReactModalPortal"
+              >
+                <div
+                  class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+                >
+                  <div
+                    aria-label="Command Palette"
+                    class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                    role="dialog"
+                    tabindex="-1"
+                  >
+                    <div>
+                      <div
+                        class="atom-header"
+                      />
+                      <div
+                        aria-expanded="true"
+                        aria-haspopup="listbox"
+                        aria-owns="react-autowhatever-1"
+                        class="atom-container atom-containerOpen"
+                        role="combobox"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="react-autowhatever-1"
+                          autocomplete="off"
+                          class="atom-input atom-inputOpen"
+                          placeholder="Type a command"
+                          type="text"
+                          value="Stop All Data Imports"
+                        />
+                        <div
+                          class="atom-suggestionsContainer atom-suggestionsContainerOpen"
+                          id="react-autowhatever-1"
+                          role="listbox"
+                        >
+                          <ul
+                            class="atom-suggestionsList"
+                            role="listbox"
+                          >
+                            <li
+                              aria-selected="false"
+                              class="atom-suggestion atom-suggestionFirst"
+                              data-suggestion-index="0"
+                              id="react-autowhatever-1--item-0"
+                              role="option"
+                            >
+                              <div
+                                class="item"
+                              >
+                                <span>
+                                  <b>
+                                    Start
+                                  </b>
+                                   All Data Imports
+                                </span>
+                              </div>
+                            </li>
+                            <li
+                              aria-selected="false"
+                              class="atom-suggestion"
+                              data-suggestion-index="1"
+                              id="react-autowhatever-1--item-1"
+                              role="option"
+                            >
+                              <div
+                                class="item"
+                              >
+                                <span>
+                                  <b>
+                                    St
+                                  </b>
+                                  op 
+                                  <b>
+                                    A
+                                  </b>
+                                  ll Data Impo
+                                  <b>
+                                    rt
+                                  </b>
+                                  s
+                                </span>
+                              </div>
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ReactModalPortal"
+              >
+                <div
+                  class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+                >
+                  <div
+                    aria-label="Command Palette"
+                    class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                    role="dialog"
+                    tabindex="-1"
+                  >
+                    <div>
+                      <div
+                        class="atom-header"
+                      />
+                      <div
+                        aria-expanded="true"
+                        aria-haspopup="listbox"
+                        aria-owns="react-autowhatever-1"
+                        class="atom-container atom-containerOpen"
+                        role="combobox"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="react-autowhatever-1"
+                          autocomplete="off"
+                          class="atom-input atom-inputOpen"
+                          placeholder="Type a command"
+                          type="text"
+                          value="Start All Data Imports"
+                        />
+                        <div
+                          class="atom-suggestionsContainer atom-suggestionsContainerOpen"
+                          id="react-autowhatever-1"
+                          role="listbox"
+                        >
+                          <ul
+                            class="atom-suggestionsList"
+                            role="listbox"
+                          >
+                            <li
+                              aria-selected="false"
+                              class="atom-suggestion atom-suggestionFirst"
+                              data-suggestion-index="0"
+                              id="react-autowhatever-1--item-0"
+                              role="option"
+                            >
+                              <div
+                                class="item"
+                              >
+                                <span>
+                                  <b>
+                                    Start
+                                  </b>
+                                   All Data Imports
+                                </span>
+                              </div>
+                            </li>
+                            <li
+                              aria-selected="false"
+                              class="atom-suggestion"
+                              data-suggestion-index="1"
+                              id="react-autowhatever-1--item-1"
+                              role="option"
+                            >
+                              <div
+                                class="item"
+                              >
+                                <span>
+                                  <b>
+                                    St
+                                  </b>
+                                  op 
+                                  <b>
+                                    A
+                                  </b>
+                                  ll Data Impo
+                                  <b>
+                                    rt
+                                  </b>
+                                  s
+                                </span>
+                              </div>
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ReactModalPortal"
+              >
+                <div
+                  class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+                >
+                  <div
+                    aria-label="Command Palette"
+                    class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                    role="dialog"
+                    tabindex="-1"
+                  >
+                    <div
+                      class="default-spinner atom-spinner modal"
+                      role="status"
+                    >
+                      <span
+                        class="sr-only"
+                      >
+                        Loading...
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ReactModalPortal"
+              >
+                <div
+                  class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+                >
+                  <div
+                    aria-label="Command Palette"
+                    class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                    role="dialog"
+                    tabindex="-1"
+                  >
+                    <div
+                      class="default-spinner atom-spinner modal"
+                      role="status"
+                    >
+                      <span
+                        class="sr-only"
+                      >
+                        Loading...
+                      </span>
                     </div>
                   </div>
                 </div>
@@ -11374,9 +12466,6 @@ exports[`Opening the palette displays the suggestion list 1`] = `
           />
           <div
             class="ReactModalPortal"
-          />
-          <div
-            class="ReactModalPortal"
           >
             <div
               class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
@@ -14079,9 +15168,6 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                   </div>
                 </div>
               </div>
-              <div
-                class="ReactModalPortal"
-              />
               <div
                 class="ReactModalPortal"
               />

--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -80,9 +80,7 @@ class CommandPalette extends React.Component {
     this.onSelect = this.onSelect.bind(this);
 
     // eslint-disable-next-line prettier/prettier
-    this.onSuggestionsFetchRequested = this.onSuggestionsFetchRequested.bind(
-      this
-    );
+    this.onSuggestionsFetchRequested = this.onSuggestionsFetchRequested.bind(this);
     this.onSuggestionsClearRequested = this.onSuggestionsClearRequested.bind(
       this
     );
@@ -130,19 +128,6 @@ class CommandPalette extends React.Component {
         suggestions: this.fetchData()
       });
     }
-  }
-
-
-  // returns user typed queries only
-  // wont return selections or keyboard navigation
-  // just input
-  getInputOnTextTyped(event, newValue) {
-    const { key, type } = event;
-    if (key !== "ArrowUp" && key !== "ArrowDown" && type !== "click") {
-      console.log(event.type, newValue);
-      return newValue;
-    } 
-    return null;
   }
 
   onChange(event, { newValue }) {
@@ -200,6 +185,17 @@ class CommandPalette extends React.Component {
     //   suggestions: []
     // });
     return true;
+  }
+
+  // returns user typed queries only
+  // wont return selections or keyboard navigation
+  // just input
+  getInputOnTextTyped(event, newValue) {
+    const { key, type } = event;
+    if (key !== "ArrowUp" && key !== "ArrowDown" && type !== "click") {
+      return newValue;
+    }
+    return null;
   }
 
   afterOpenModal() {

--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -132,12 +132,25 @@ class CommandPalette extends React.Component {
     }
   }
 
+
+  // returns user typed queries only
+  // wont return selections or keyboard navigation
+  // just input
+  getInputOnTextTyped(event, newValue) {
+    const { key, type } = event;
+    if (key !== "ArrowUp" && key !== "ArrowDown" && type !== "click") {
+      console.log(event.type, newValue);
+      return newValue;
+    } 
+    return null;
+  }
+
   onChange(event, { newValue }) {
     const { onChange } = this.props;
     this.setState({
       value: newValue
     });
-    return onChange(newValue);
+    return onChange(newValue, this.getInputOnTextTyped(event, newValue));
   }
 
   onSelect(suggestion = null) {

--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -192,7 +192,12 @@ class CommandPalette extends React.Component {
   // just input
   getInputOnTextTyped(event, newValue) {
     const { key, type } = event;
-    if (key !== "ArrowUp" && key !== "ArrowDown" && type !== "click") {
+    if (
+      key !== "ArrowUp" &&
+      key !== "ArrowDown" &&
+      key !== "Enter" &&
+      type !== "click"
+    ) {
       return newValue;
     }
     return null;

--- a/src/command-palette.test.js
+++ b/src/command-palette.test.js
@@ -17,6 +17,7 @@ import sampleHeader from "../examples/sampleHeader";
 import sampleAtomCommand from "../examples/sampleAtomCommand";
 import sampleChromeCommand from "../examples/sampleChromeCommand";
 import chromeTheme from "../themes/chrome-theme";
+import { clickDown, clickUp, clickEnter } from "./test-helpers";
 
 // React 16 Enzyme adapter
 Enzyme.configure({ adapter: new Adapter() });
@@ -343,19 +344,6 @@ describe("Opening the palette", () => {
     spyOnSelect.mockClear();
   });
 
-  it('fires the onChange event and returns the "newValue"', () => {
-    const spyOnChange = jest.fn();
-    const mock = { newValue: "foo" };
-    const commandPalette = mount(
-      <CommandPalette commands={mockCommands} onChange={spyOnChange} />
-    );
-    commandPalette.instance().onChange({}, mock);
-    expect(spyOnChange).toHaveBeenCalled();
-    // verify the spyed callback contains returns the input value
-    expect(spyOnChange.mock.calls[0][0]).toBe(mock.newValue);
-    spyOnChange.mockClear();
-  });
-
   it("fires the onAfterOpen event", () => {
     const spyOnAfterOpen = jest.fn();
     const commandPalette = mount(
@@ -500,6 +488,157 @@ describe("Closing the palette", () => {
     expect(spyHandleCloseModal).toHaveBeenCalled();
     expect(spyHandleCloseModal.mock.calls).toHaveLength(1);
     expect(commandPalette.state("showModal")).toEqual(false);
+  });
+});
+
+describe("props.onChange", () => {
+  describe("Opening the Command Palette", () => {
+    it("should fire onChange", () => {
+      const spyOnChange = jest.fn();
+      const mock = { newValue: "foo" };
+      const commandPalette = mount(
+        <CommandPalette commands={mockCommands} onChange={spyOnChange} />
+      );
+      commandPalette.instance().onChange({}, mock);
+      expect(spyOnChange).toHaveBeenCalled();
+      // verify the spyed callback contains returns the input value
+      expect(spyOnChange.mock.calls[0][0]).toBe(mock.newValue);
+      spyOnChange.mockClear();
+    });
+  });
+
+  describe("Typing text into the input field", () => {
+    it("should fire onChange", () => {
+      const spyOnChange = jest.fn();
+      const commandPalette = mount(
+        <CommandPalette commands={mockCommands} onChange={spyOnChange} open />
+      );
+      commandPalette
+        .find("input")
+        .simulate("change", { target: { value: "f" } });
+      expect(spyOnChange).toHaveBeenCalled();
+      spyOnChange.mockClear();
+    });
+
+    it("should return the value of the input field", () => {
+      const spyOnChange = jest.fn();
+      const mock = { newValue: "foo" };
+      const commandPalette = mount(
+        <CommandPalette commands={mockCommands} onChange={spyOnChange} open />
+      );
+      commandPalette
+        .find("input")
+        .simulate("change", { target: { value: mock.newValue } });
+      expect(spyOnChange).toHaveBeenCalled();
+      // verify the spied callback contains returns the input value
+      expect(spyOnChange.mock.calls[0][0]).toBe(mock.newValue);
+      spyOnChange.mockClear();
+    });
+
+    it("should return the query containing user's typed text", () => {
+      const mock = { inputValue: "Start", userQuery: "Start" };
+      const handleOnClick = function() {};
+      const spyOnChange = jest.fn().mockImplementation(handleOnClick);
+      const commandPalette = mount(
+        <CommandPalette commands={mockCommands} onChange={spyOnChange} open />
+      );
+      commandPalette
+        .find("input")
+        .simulate("change", { target: { value: mock.inputValue } });
+      expect(spyOnChange).toHaveBeenCalled();
+      // verify the spied callback contains returns the input value
+      expect(spyOnChange.mock.calls[0][1]).toBe(mock.inputValue);
+      expect(spyOnChange.mock.calls[0][0]).toBe(mock.userQuery);
+      spyOnChange.mockClear();
+    });
+  });
+
+  // userQuery (inputValue, userQuery) { ... }
+  describe("Navigating suggestions", () => {
+    let handleOnClick;
+    let spyOnChange;
+    let commandPalette;
+    let input;
+
+    beforeEach(() => {
+      handleOnClick = function() {};
+      spyOnChange = jest.fn().mockImplementation(handleOnClick);
+      commandPalette = mount(
+        <CommandPalette commands={mockCommands} onChange={spyOnChange} open />
+      );
+      input = commandPalette
+        .find("input")
+        .simulate("change", { target: { value: "Start" } })
+        .instance();
+    });
+
+    afterEach(() => {
+      spyOnChange.mockClear();
+    });
+
+    it("should return null when the user pressed the down arrow key", () => {
+      // simulate user typeing some text
+      expect(spyOnChange).toHaveBeenCalled();
+      expect(spyOnChange.mock.calls[0][0]).toBe("Start");
+      expect(spyOnChange.mock.calls[0][1]).toBe("Start");
+
+      // First suggestion is always highlighted, pressing ArrowDown
+      // highlights the second item in the suggestion list
+      clickDown(input);
+      expect(spyOnChange).toHaveBeenCalledTimes(2);
+      expect(spyOnChange.mock.calls[1][0]).toBe("Stop All Data Imports");
+      expect(spyOnChange.mock.calls[1][1]).toBe(null);
+    });
+
+    it("should return null when the user pressed the up arrow  key", () => {
+      // simulate user typeing some text
+      expect(spyOnChange).toHaveBeenCalled();
+      expect(spyOnChange.mock.calls[0][0]).toBe("Start");
+      expect(spyOnChange.mock.calls[0][1]).toBe("Start");
+
+      // First suggestion is always highlighted, pressing ArrowDown
+      // highlights the second item in the suggestion list
+      clickDown(input);
+      expect(spyOnChange).toHaveBeenCalledTimes(2);
+      expect(spyOnChange.mock.calls[1][0]).toBe("Stop All Data Imports");
+      expect(spyOnChange.mock.calls[1][1]).toBe(null);
+
+      clickUp(input);
+      expect(spyOnChange).toHaveBeenCalledTimes(3);
+      expect(spyOnChange.mock.calls[2][0]).toBe("Start All Data Imports");
+      expect(spyOnChange.mock.calls[2][1]).toBe(null);
+    });
+
+    it("should return null when the user pressed the Enter key", () => {
+      // simulate user typeing some text
+      expect(spyOnChange).toHaveBeenCalled();
+      expect(spyOnChange.mock.calls[0][0]).toBe("Start");
+      expect(spyOnChange.mock.calls[0][1]).toBe("Start");
+
+      // First suggestion is always highlighted, pressing ArrowDown
+      // highlights the second item in the suggestion list
+      clickEnter(input);
+      expect(spyOnChange).toHaveBeenCalledTimes(2);
+      expect(spyOnChange.mock.calls[1][0]).toBe("Start All Data Imports");
+      expect(spyOnChange.mock.calls[1][1]).toBe(null);
+    });
+
+    it("should return null when the user clicks a suggestion with mouse", () => {
+      // simulate user typeing some text
+      expect(spyOnChange).toHaveBeenCalled();
+      expect(spyOnChange.mock.calls[0][0]).toBe("Start");
+      expect(spyOnChange.mock.calls[0][1]).toBe("Start");
+
+      // First suggestion is always highlighted, pressing ArrowDown
+      // highlights the second item in the suggestion list
+      const firstSuggestion = commandPalette
+        .find("#react-autowhatever-1--item-0")
+        .first();
+      firstSuggestion.simulate("click");
+      expect(spyOnChange).toHaveBeenCalledTimes(2);
+      expect(spyOnChange.mock.calls[1][0]).toBe("Start All Data Imports");
+      expect(spyOnChange.mock.calls[1][1]).toBe(null);
+    });
   });
 });
 

--- a/src/command-palette.test.js
+++ b/src/command-palette.test.js
@@ -436,7 +436,8 @@ describe("Opening the palette", () => {
       spyHandleOpenModal.mockClear();
     });
 
-    it('opens the commandPalette when pressing either "ctrl+shift+p" or "ctrl+k" keys', () => {
+    it(`opens the commandPalette when pressing 
+    either "ctrl+shift+p" or "ctrl+k" keys`, () => {
       const spyHandleOpenModal = jest.spyOn(
         CommandPalette.prototype,
         "handleOpenModal"

--- a/src/test-helpers.js
+++ b/src/test-helpers.js
@@ -1,0 +1,20 @@
+import { Simulate } from "react-dom/test-utils";
+
+export const clickDown = (input, count = 1) => {
+  for (let i = 0; i < count; i++) {
+    // throws if key is missing
+    Simulate.keyDown(input, { key: "ArrowDown", keyCode: 40 });
+  }
+};
+
+export const clickUp = (input, count = 1) => {
+  for (let i = 0; i < count; i++) {
+    // throws if key is missing
+    Simulate.keyDown(input, { key: "ArrowUp", keyCode: 38 });
+  }
+};
+
+export const clickEnter = input => {
+  // throws if key is missing
+  Simulate.keyDown(input, { key: "Enter", keyCode: 13 });
+};

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -191,13 +191,14 @@ storiesOf("Command Palette", module)
     <CommandPalette
       open
       commands={commands}
-      onChange={(value, query) => {
+      onChange={(inputValue, userQuery) => {
         console.log(
-        `The input value was changed to: \n
-        ${value}\n
+          `The input value was changed to: \n
+        ${inputValue}\n
         The user typed:\n
-        ${query}
-        `);
+        ${userQuery}
+        `
+        );
       }}
     />
   ))

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -191,9 +191,12 @@ storiesOf("Command Palette", module)
     <CommandPalette
       open
       commands={commands}
-      onChange={value => {
-        console.log(`The input value was changed to: \n
-        ${value}
+      onChange={(value, query) => {
+        console.log(
+        `The input value was changed to: \n
+        ${value}\n
+        The user typed:\n
+        ${query}
         `);
       }}
     />


### PR DESCRIPTION
Add onChange query which returns only the input value of the entry the user types. It ignores values sent via keyboard navigation or clicking to select / pressing the enter key

Note that node version was bumped to 13.6.0 in master `nvm install` to get the latest node when testing

![sample](https://www.dropbox.com/s/ztapsb1j5xxbuxz/2020-01-13%2020.44.29.gif?raw=1)

Snippet:

```jsx
    <CommandPalette
      open
      commands={commands}
      onChange={(value, query) => {
        console.log(
          `The input value was changed to: \n
          ${value}\n
          The user typed:\n
          ${query}
          `);
      }}
    />
```

Alternatively a new onUserTypedInputText event could be created. I’m presently on the fence about the naming for such and event. Feedback wanted