### PR TITLE
Add resetInputOnClose prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ const commands = [{
 
 * ```closeOnSelect``` a _boolean_, when set to true the command palette will close immediately when the user makes a selection. Defaults to "false".
 
+* ```resetInputOnClose``` a _boolean_ which indicates whether to reset the user's query to `defaultInputValue` when the command palette closes. Defaults to "false".
+
 * ```placeholder``` a _string_ that contains a short text description which is displayed inside the the input field until the user provides input. Defaults to "Type a command".
 
 * ```hotKeys``` a _string_ or _array of strings_ that contain a keyboard shortcut for opening/closing the palette. Defaults to "_command+shift+p_". Uses [mousetrap key combos](https://craig.is/killing/mice)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ const commands = [{
 
 * ```header``` a _string_ or a _React.ComponentType_ which provides a helpful description for the usage of the command palette. The component is displayed at the top of the command palette. The header is not displayed by default. see: examples/sampleInstruction.js for reference.
 
-* ```closeOnSelect``` a _boolean_, when set to true the command palette will close immediateley when the user makes a selection. Defaults to "false".
+* ```closeOnSelect``` a _boolean_, when set to true the command palette will close immediately when the user makes a selection. Defaults to "false".
 
 * ```placeholder``` a _string_ that contains a short text description which is displayed inside the the input field until the user provides input. Defaults to "Type a command".
 
@@ -72,7 +72,7 @@ const commands = [{
 
 * ```defaultInputValue``` a _string_ that determines the value of the text in the input field. By default the defaultInputValue is an empty string.
 
-* ```options``` options controls how fuzzy search is configured. Note: use at your own risk, this is likley to change in the future. The search options are derived from these [fuzzysort options](https://github.com/farzher/fuzzysort#options). However the command palette options prop must have the following values included to function correctly:
+* ```options``` options controls how fuzzy search is configured. Note: use at your own risk, this is likely to change in the future. The search options are derived from these [fuzzysort options](https://github.com/farzher/fuzzysort#options). However the command palette options prop must have the following values included to function correctly:
 
   ```js
     key: "name", // default is "name"
@@ -90,7 +90,7 @@ const commands = [{
     <CommandPalette
       commands={commands}
       onChange={(inputValue, userQuery) => {
-        alert(`The input inputVwas changed to:\n
+        alert(`The input was changed to:\n
         ${inputValue}\n
         \n
         The user typed:\n
@@ -150,10 +150,10 @@ Note: It is not called if _open_ is changed by other means. Passes through to th
     ...
   ```
 
-* ```reactModalParentSelector``` a selector compatible with querySelector. By default, the modal portal will be appended to the document's body. You can choose a different parent element by selector. If you do this, please ensure that your app element is set correctly. The app element should not be a parent of the modal, to prevent modal content from being hidden to screenreaders while it is open. 
+* ```reactModalParentSelector``` a selector compatible with querySelector. By default, the modal portal will be appended to the document's body. You can choose a different parent element by selector. If you do this, please ensure that your app element is set correctly. The app element should not be a parent of the modal, to prevent modal content from being hidden to screenreaders while it is open.
 
-* ```renderCommand``` a _React.func_. By default, react-command-palette will render the suggestion.name_ for each command.  However, if passed a custom react component _renderCommand_ will display the command using any template you can imageine. The _renderCommand_ code signature follows the same coding pattern defined by react-autosuggest's  renderSuggestion property.
-  
+* ```renderCommand``` a _React.func_. By default, react-command-palette will render the suggestion.name_ for each command.  However, if passed a custom react component _renderCommand_ will display the command using any template you can imagine. The _renderCommand_ code signature follows the same coding pattern defined by react-autosuggest's  renderSuggestion property.
+
   ```jsx
   function RenderCommand(suggestion) {
     // A suggestion object will be passed to your custom component for each command
@@ -187,11 +187,11 @@ Note: It is not called if _open_ is changed by other means. Passes through to th
 
   *Important:* _renderCommand_ must be a pure function (react-autosuggest, upon which this is based will optimize rendering performance based on this assumption).
 
-* ```maxDisplayed``` a _number_ between 1 and 500 that determines the maxium number of commands that will be rendered on screen. Defaults to 7
+* ```maxDisplayed``` a _number_ between 1 and 500 that determines the maximum number of commands that will be rendered on screen. Defaults to 7
 
 * ```spinner``` a _string_ or a _React.ComponentType_ that is displayed when the user selects an item. If a custom spinner is not set then the default spinner will be used. If a custom component or string is provided then it will automatically be wrapped inside a div with a _role="status"_ attribute. If a component is provided then it will be be wrapped in a div that also contains a sibling node with a div contain "Loading..." visible only to screen readers.
 
-* ```showSpinnerOnSelect``` a _boolean_ which displays a loading indicator immediatley after a command has been selected. When true the spinner is enabled when false the spinner is disabled. Useful when dynamicaly loading lists of a commands based upon user selections. Setting both _showSpinnerOnSelect_ and  _closeOnSelect_ to false will keep the palette open and allow a new list of commands to be loaded, see the [dynamic lists example](https://codesandbox.io/s/react-command-palette-dynamic-lists-p2xo9?fontsize=14&hidenavigation=1&theme=dark).
+* ```showSpinnerOnSelect``` a _boolean_ which displays a loading indicator immediately after a command has been selected. When true the spinner is enabled when false the spinner is disabled. Useful when dynamically loading lists of a commands based upon user selections. Setting both _showSpinnerOnSelect_ and  _closeOnSelect_ to false will keep the palette open and allow a new list of commands to be loaded, see the [dynamic lists example](https://codesandbox.io/s/react-command-palette-dynamic-lists-p2xo9?fontsize=14&hidenavigation=1&theme=dark).
 
 * ```theme``` enables you to apply a sample or custom look-n-feel.
   Two themes are included with the command palette, Chrome and Atom. The CommandPalette comes with the Atom theme enabled default.
@@ -300,7 +300,7 @@ $ docker run -it -v ${PWD}:/app -p 6006:6006 react-command-palette npm start
 Open your browser to http://localhost:6006/ and you should see the app. Try making a change to the command-palette component within your code editor. You should see the app hot-reload. Kill the server once done.
 
 ### Package for production with Docker:
-CodeFresh.io will autmatically run this build to prepare the package 
+CodeFresh.io will automatically run this build to prepare the package
 for publication to npm whenever a pull request is merged to master.
 
 ## Sponsors

--- a/src/__snapshots__/command-palette.test.js.snap
+++ b/src/__snapshots__/command-palette.test.js.snap
@@ -107,6 +107,7 @@ exports[`Command List renders a command 1`] = `
   placeholder="Type a command"
   reactModalParentSelector="body"
   renderCommand={null}
+  resetInputOnClose={false}
   showSpinnerOnSelect={true}
   theme={
     Object {
@@ -927,6 +928,90 @@ exports[`Command List renders a command 1`] = `
                         </li>
                       </ul>
                     </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ReactModalPortal"
+          >
+            <div
+              class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+            >
+              <div
+                aria-label="Command Palette"
+                class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                role="dialog"
+                tabindex="-1"
+              >
+                <div>
+                  <div
+                    class="atom-header"
+                  />
+                  <div
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    aria-owns="react-autowhatever-1"
+                    class="atom-container"
+                    role="combobox"
+                  >
+                    <input
+                      aria-autocomplete="list"
+                      aria-controls="react-autowhatever-1"
+                      autocomplete="off"
+                      class="atom-input"
+                      placeholder="Type a command"
+                      type="text"
+                      value="my query"
+                    />
+                    <div
+                      class="atom-suggestionsContainer"
+                      id="react-autowhatever-1"
+                      role="listbox"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ReactModalPortal"
+          >
+            <div
+              class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+            >
+              <div
+                aria-label="Command Palette"
+                class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                role="dialog"
+                tabindex="-1"
+              >
+                <div>
+                  <div
+                    class="atom-header"
+                  />
+                  <div
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    aria-owns="react-autowhatever-1"
+                    class="atom-container"
+                    role="combobox"
+                  >
+                    <input
+                      aria-autocomplete="list"
+                      aria-controls="react-autowhatever-1"
+                      autocomplete="off"
+                      class="atom-input"
+                      placeholder="Type a command"
+                      type="text"
+                      value="default"
+                    />
+                    <div
+                      class="atom-suggestionsContainer"
+                      id="react-autowhatever-1"
+                      role="listbox"
+                    />
                   </div>
                 </div>
               </div>
@@ -5761,6 +5846,90 @@ exports[`Command List renders a command 1`] = `
                         class="atom-header"
                       />
                       <div
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        aria-owns="react-autowhatever-1"
+                        class="atom-container"
+                        role="combobox"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="react-autowhatever-1"
+                          autocomplete="off"
+                          class="atom-input"
+                          placeholder="Type a command"
+                          type="text"
+                          value="my query"
+                        />
+                        <div
+                          class="atom-suggestionsContainer"
+                          id="react-autowhatever-1"
+                          role="listbox"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ReactModalPortal"
+              >
+                <div
+                  class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+                >
+                  <div
+                    aria-label="Command Palette"
+                    class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                    role="dialog"
+                    tabindex="-1"
+                  >
+                    <div>
+                      <div
+                        class="atom-header"
+                      />
+                      <div
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        aria-owns="react-autowhatever-1"
+                        class="atom-container"
+                        role="combobox"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="react-autowhatever-1"
+                          autocomplete="off"
+                          class="atom-input"
+                          placeholder="Type a command"
+                          type="text"
+                          value="default"
+                        />
+                        <div
+                          class="atom-suggestionsContainer"
+                          id="react-autowhatever-1"
+                          role="listbox"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ReactModalPortal"
+              >
+                <div
+                  class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+                >
+                  <div
+                    aria-label="Command Palette"
+                    class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                    role="dialog"
+                    tabindex="-1"
+                  >
+                    <div>
+                      <div
+                        class="atom-header"
+                      />
+                      <div
                         aria-expanded="true"
                         aria-haspopup="listbox"
                         aria-owns="react-autowhatever-1"
@@ -10124,6 +10293,7 @@ exports[`Command List renders a command 1`] = `
                                   placeholder="Type a command"
                                   reactModalParentSelector="body"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -10332,6 +10502,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
   placeholder="Type a command"
   reactModalParentSelector="body"
   renderCommand={null}
+  resetInputOnClose={false}
   showSpinnerOnSelect={true}
   theme={
     Object {
@@ -11152,6 +11323,90 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                         </li>
                       </ul>
                     </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ReactModalPortal"
+          >
+            <div
+              class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+            >
+              <div
+                aria-label="Command Palette"
+                class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                role="dialog"
+                tabindex="-1"
+              >
+                <div>
+                  <div
+                    class="atom-header"
+                  />
+                  <div
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    aria-owns="react-autowhatever-1"
+                    class="atom-container"
+                    role="combobox"
+                  >
+                    <input
+                      aria-autocomplete="list"
+                      aria-controls="react-autowhatever-1"
+                      autocomplete="off"
+                      class="atom-input"
+                      placeholder="Type a command"
+                      type="text"
+                      value="my query"
+                    />
+                    <div
+                      class="atom-suggestionsContainer"
+                      id="react-autowhatever-1"
+                      role="listbox"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ReactModalPortal"
+          >
+            <div
+              class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+            >
+              <div
+                aria-label="Command Palette"
+                class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                role="dialog"
+                tabindex="-1"
+              >
+                <div>
+                  <div
+                    class="atom-header"
+                  />
+                  <div
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    aria-owns="react-autowhatever-1"
+                    class="atom-container"
+                    role="combobox"
+                  >
+                    <input
+                      aria-autocomplete="list"
+                      aria-controls="react-autowhatever-1"
+                      autocomplete="off"
+                      class="atom-input"
+                      placeholder="Type a command"
+                      type="text"
+                      value="default"
+                    />
+                    <div
+                      class="atom-suggestionsContainer"
+                      id="react-autowhatever-1"
+                      role="listbox"
+                    />
                   </div>
                 </div>
               </div>
@@ -13881,6 +14136,90 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                         class="atom-header"
                       />
                       <div
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        aria-owns="react-autowhatever-1"
+                        class="atom-container"
+                        role="combobox"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="react-autowhatever-1"
+                          autocomplete="off"
+                          class="atom-input"
+                          placeholder="Type a command"
+                          type="text"
+                          value="my query"
+                        />
+                        <div
+                          class="atom-suggestionsContainer"
+                          id="react-autowhatever-1"
+                          role="listbox"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ReactModalPortal"
+              >
+                <div
+                  class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+                >
+                  <div
+                    aria-label="Command Palette"
+                    class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                    role="dialog"
+                    tabindex="-1"
+                  >
+                    <div>
+                      <div
+                        class="atom-header"
+                      />
+                      <div
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        aria-owns="react-autowhatever-1"
+                        class="atom-container"
+                        role="combobox"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="react-autowhatever-1"
+                          autocomplete="off"
+                          class="atom-input"
+                          placeholder="Type a command"
+                          type="text"
+                          value="default"
+                        />
+                        <div
+                          class="atom-suggestionsContainer"
+                          id="react-autowhatever-1"
+                          role="listbox"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ReactModalPortal"
+              >
+                <div
+                  class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+                >
+                  <div
+                    aria-label="Command Palette"
+                    class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                    role="dialog"
+                    tabindex="-1"
+                  >
+                    <div>
+                      <div
+                        class="atom-header"
+                      />
+                      <div
                         aria-expanded="true"
                         aria-haspopup="listbox"
                         aria-owns="react-autowhatever-1"
@@ -16159,6 +16498,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   placeholder="Type a command"
                                   reactModalParentSelector="body"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -16361,6 +16701,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   placeholder="Type a command"
                                   reactModalParentSelector="body"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -16563,6 +16904,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   placeholder="Type a command"
                                   reactModalParentSelector="body"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -16766,6 +17108,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   placeholder="Type a command"
                                   reactModalParentSelector="body"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -16970,6 +17313,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   placeholder="Type a command"
                                   reactModalParentSelector="body"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -17172,6 +17516,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   placeholder="Type a command"
                                   reactModalParentSelector="body"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -17374,6 +17719,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   placeholder="Type a command"
                                   reactModalParentSelector="body"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -17548,6 +17894,7 @@ exports[`props.display should not display the command palette in react-modal whe
   placeholder="Type a command"
   reactModalParentSelector="body"
   renderCommand={null}
+  resetInputOnClose={false}
   showSpinnerOnSelect={true}
   theme={
     Object {
@@ -18034,6 +18381,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         placeholder="Type a command"
                         reactModalParentSelector="body"
                         renderCommand={null}
+                        resetInputOnClose={false}
                         showSpinnerOnSelect={true}
                         suggestion={
                           Object {
@@ -18236,6 +18584,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         placeholder="Type a command"
                         reactModalParentSelector="body"
                         renderCommand={null}
+                        resetInputOnClose={false}
                         showSpinnerOnSelect={true}
                         suggestion={
                           Object {
@@ -18438,6 +18787,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         placeholder="Type a command"
                         reactModalParentSelector="body"
                         renderCommand={null}
+                        resetInputOnClose={false}
                         showSpinnerOnSelect={true}
                         suggestion={
                           Object {
@@ -18641,6 +18991,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         placeholder="Type a command"
                         reactModalParentSelector="body"
                         renderCommand={null}
+                        resetInputOnClose={false}
                         showSpinnerOnSelect={true}
                         suggestion={
                           Object {
@@ -18845,6 +19196,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         placeholder="Type a command"
                         reactModalParentSelector="body"
                         renderCommand={null}
+                        resetInputOnClose={false}
                         showSpinnerOnSelect={true}
                         suggestion={
                           Object {
@@ -19047,6 +19399,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         placeholder="Type a command"
                         reactModalParentSelector="body"
                         renderCommand={null}
+                        resetInputOnClose={false}
                         showSpinnerOnSelect={true}
                         suggestion={
                           Object {
@@ -19249,6 +19602,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         placeholder="Type a command"
                         reactModalParentSelector="body"
                         renderCommand={null}
+                        resetInputOnClose={false}
                         showSpinnerOnSelect={true}
                         suggestion={
                           Object {
@@ -19516,6 +19870,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
   placeholder="Type a command"
   reactModalParentSelector="#main"
   renderCommand={null}
+  resetInputOnClose={false}
   showSpinnerOnSelect={true}
   theme={
     Object {
@@ -20336,6 +20691,90 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                         </li>
                       </ul>
                     </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ReactModalPortal"
+          >
+            <div
+              class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+            >
+              <div
+                aria-label="Command Palette"
+                class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                role="dialog"
+                tabindex="-1"
+              >
+                <div>
+                  <div
+                    class="atom-header"
+                  />
+                  <div
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    aria-owns="react-autowhatever-1"
+                    class="atom-container"
+                    role="combobox"
+                  >
+                    <input
+                      aria-autocomplete="list"
+                      aria-controls="react-autowhatever-1"
+                      autocomplete="off"
+                      class="atom-input"
+                      placeholder="Type a command"
+                      type="text"
+                      value="my query"
+                    />
+                    <div
+                      class="atom-suggestionsContainer"
+                      id="react-autowhatever-1"
+                      role="listbox"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ReactModalPortal"
+          >
+            <div
+              class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+            >
+              <div
+                aria-label="Command Palette"
+                class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                role="dialog"
+                tabindex="-1"
+              >
+                <div>
+                  <div
+                    class="atom-header"
+                  />
+                  <div
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    aria-owns="react-autowhatever-1"
+                    class="atom-container"
+                    role="combobox"
+                  >
+                    <input
+                      aria-autocomplete="list"
+                      aria-controls="react-autowhatever-1"
+                      autocomplete="off"
+                      class="atom-input"
+                      placeholder="Type a command"
+                      type="text"
+                      value="default"
+                    />
+                    <div
+                      class="atom-suggestionsContainer"
+                      id="react-autowhatever-1"
+                      role="listbox"
+                    />
                   </div>
                 </div>
               </div>
@@ -22450,6 +22889,90 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                         class="atom-header"
                       />
                       <div
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        aria-owns="react-autowhatever-1"
+                        class="atom-container"
+                        role="combobox"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="react-autowhatever-1"
+                          autocomplete="off"
+                          class="atom-input"
+                          placeholder="Type a command"
+                          type="text"
+                          value="my query"
+                        />
+                        <div
+                          class="atom-suggestionsContainer"
+                          id="react-autowhatever-1"
+                          role="listbox"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ReactModalPortal"
+              >
+                <div
+                  class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+                >
+                  <div
+                    aria-label="Command Palette"
+                    class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                    role="dialog"
+                    tabindex="-1"
+                  >
+                    <div>
+                      <div
+                        class="atom-header"
+                      />
+                      <div
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        aria-owns="react-autowhatever-1"
+                        class="atom-container"
+                        role="combobox"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="react-autowhatever-1"
+                          autocomplete="off"
+                          class="atom-input"
+                          placeholder="Type a command"
+                          type="text"
+                          value="default"
+                        />
+                        <div
+                          class="atom-suggestionsContainer"
+                          id="react-autowhatever-1"
+                          role="listbox"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ReactModalPortal"
+              >
+                <div
+                  class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+                >
+                  <div
+                    aria-label="Command Palette"
+                    class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                    role="dialog"
+                    tabindex="-1"
+                  >
+                    <div>
+                      <div
+                        class="atom-header"
+                      />
+                      <div
                         aria-expanded="true"
                         aria-haspopup="listbox"
                         aria-owns="react-autowhatever-1"
@@ -24114,6 +24637,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   placeholder="Type a command"
                                   reactModalParentSelector="#main"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -24317,6 +24841,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   placeholder="Type a command"
                                   reactModalParentSelector="#main"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -24520,6 +25045,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   placeholder="Type a command"
                                   reactModalParentSelector="#main"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -24724,6 +25250,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   placeholder="Type a command"
                                   reactModalParentSelector="#main"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -24929,6 +25456,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   placeholder="Type a command"
                                   reactModalParentSelector="#main"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -25132,6 +25660,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   placeholder="Type a command"
                                   reactModalParentSelector="#main"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -25335,6 +25864,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   placeholder="Type a command"
                                   reactModalParentSelector="#main"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -25511,6 +26041,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
   placeholder="Type a command"
   reactModalParentSelector="body"
   renderCommand={null}
+  resetInputOnClose={false}
   showSpinnerOnSelect={true}
   theme={
     Object {
@@ -26331,6 +26862,90 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                         </li>
                       </ul>
                     </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ReactModalPortal"
+          >
+            <div
+              class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+            >
+              <div
+                aria-label="Command Palette"
+                class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                role="dialog"
+                tabindex="-1"
+              >
+                <div>
+                  <div
+                    class="atom-header"
+                  />
+                  <div
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    aria-owns="react-autowhatever-1"
+                    class="atom-container"
+                    role="combobox"
+                  >
+                    <input
+                      aria-autocomplete="list"
+                      aria-controls="react-autowhatever-1"
+                      autocomplete="off"
+                      class="atom-input"
+                      placeholder="Type a command"
+                      type="text"
+                      value="my query"
+                    />
+                    <div
+                      class="atom-suggestionsContainer"
+                      id="react-autowhatever-1"
+                      role="listbox"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ReactModalPortal"
+          >
+            <div
+              class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+            >
+              <div
+                aria-label="Command Palette"
+                class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                role="dialog"
+                tabindex="-1"
+              >
+                <div>
+                  <div
+                    class="atom-header"
+                  />
+                  <div
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    aria-owns="react-autowhatever-1"
+                    class="atom-container"
+                    role="combobox"
+                  >
+                    <input
+                      aria-autocomplete="list"
+                      aria-controls="react-autowhatever-1"
+                      autocomplete="off"
+                      class="atom-input"
+                      placeholder="Type a command"
+                      type="text"
+                      value="default"
+                    />
+                    <div
+                      class="atom-suggestionsContainer"
+                      id="react-autowhatever-1"
+                      role="listbox"
+                    />
                   </div>
                 </div>
               </div>
@@ -27447,6 +28062,90 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                         class="atom-header"
                       />
                       <div
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        aria-owns="react-autowhatever-1"
+                        class="atom-container"
+                        role="combobox"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="react-autowhatever-1"
+                          autocomplete="off"
+                          class="atom-input"
+                          placeholder="Type a command"
+                          type="text"
+                          value="my query"
+                        />
+                        <div
+                          class="atom-suggestionsContainer"
+                          id="react-autowhatever-1"
+                          role="listbox"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ReactModalPortal"
+              >
+                <div
+                  class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+                >
+                  <div
+                    aria-label="Command Palette"
+                    class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                    role="dialog"
+                    tabindex="-1"
+                  >
+                    <div>
+                      <div
+                        class="atom-header"
+                      />
+                      <div
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        aria-owns="react-autowhatever-1"
+                        class="atom-container"
+                        role="combobox"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="react-autowhatever-1"
+                          autocomplete="off"
+                          class="atom-input"
+                          placeholder="Type a command"
+                          type="text"
+                          value="default"
+                        />
+                        <div
+                          class="atom-suggestionsContainer"
+                          id="react-autowhatever-1"
+                          role="listbox"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ReactModalPortal"
+              >
+                <div
+                  class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+                >
+                  <div
+                    aria-label="Command Palette"
+                    class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                    role="dialog"
+                    tabindex="-1"
+                  >
+                    <div>
+                      <div
+                        class="atom-header"
+                      />
+                      <div
                         aria-expanded="true"
                         aria-haspopup="listbox"
                         aria-owns="react-autowhatever-1"
@@ -28114,6 +28813,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   placeholder="Type a command"
                                   reactModalParentSelector="body"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -28318,6 +29018,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   placeholder="Type a command"
                                   reactModalParentSelector="body"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -28522,6 +29223,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   placeholder="Type a command"
                                   reactModalParentSelector="body"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -28727,6 +29429,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   placeholder="Type a command"
                                   reactModalParentSelector="body"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -28933,6 +29636,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   placeholder="Type a command"
                                   reactModalParentSelector="body"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -29137,6 +29841,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   placeholder="Type a command"
                                   reactModalParentSelector="body"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -29341,6 +30046,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   placeholder="Type a command"
                                   reactModalParentSelector="body"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -29517,6 +30223,7 @@ exports[`props.theme should render a custom theme 1`] = `
   placeholder="Type a command"
   reactModalParentSelector="body"
   renderCommand={null}
+  resetInputOnClose={false}
   showSpinnerOnSelect={true}
   theme={
     Object {
@@ -30337,6 +31044,90 @@ exports[`props.theme should render a custom theme 1`] = `
                         </li>
                       </ul>
                     </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ReactModalPortal"
+          >
+            <div
+              class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+            >
+              <div
+                aria-label="Command Palette"
+                class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                role="dialog"
+                tabindex="-1"
+              >
+                <div>
+                  <div
+                    class="atom-header"
+                  />
+                  <div
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    aria-owns="react-autowhatever-1"
+                    class="atom-container"
+                    role="combobox"
+                  >
+                    <input
+                      aria-autocomplete="list"
+                      aria-controls="react-autowhatever-1"
+                      autocomplete="off"
+                      class="atom-input"
+                      placeholder="Type a command"
+                      type="text"
+                      value="my query"
+                    />
+                    <div
+                      class="atom-suggestionsContainer"
+                      id="react-autowhatever-1"
+                      role="listbox"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ReactModalPortal"
+          >
+            <div
+              class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+            >
+              <div
+                aria-label="Command Palette"
+                class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                role="dialog"
+                tabindex="-1"
+              >
+                <div>
+                  <div
+                    class="atom-header"
+                  />
+                  <div
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    aria-owns="react-autowhatever-1"
+                    class="atom-container"
+                    role="combobox"
+                  >
+                    <input
+                      aria-autocomplete="list"
+                      aria-controls="react-autowhatever-1"
+                      autocomplete="off"
+                      class="atom-input"
+                      placeholder="Type a command"
+                      type="text"
+                      value="default"
+                    />
+                    <div
+                      class="atom-suggestionsContainer"
+                      id="react-autowhatever-1"
+                      role="listbox"
+                    />
                   </div>
                 </div>
               </div>
@@ -31916,6 +32707,90 @@ exports[`props.theme should render a custom theme 1`] = `
                         class="atom-header"
                       />
                       <div
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        aria-owns="react-autowhatever-1"
+                        class="atom-container"
+                        role="combobox"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="react-autowhatever-1"
+                          autocomplete="off"
+                          class="atom-input"
+                          placeholder="Type a command"
+                          type="text"
+                          value="my query"
+                        />
+                        <div
+                          class="atom-suggestionsContainer"
+                          id="react-autowhatever-1"
+                          role="listbox"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ReactModalPortal"
+              >
+                <div
+                  class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+                >
+                  <div
+                    aria-label="Command Palette"
+                    class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                    role="dialog"
+                    tabindex="-1"
+                  >
+                    <div>
+                      <div
+                        class="atom-header"
+                      />
+                      <div
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        aria-owns="react-autowhatever-1"
+                        class="atom-container"
+                        role="combobox"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="react-autowhatever-1"
+                          autocomplete="off"
+                          class="atom-input"
+                          placeholder="Type a command"
+                          type="text"
+                          value="default"
+                        />
+                        <div
+                          class="atom-suggestionsContainer"
+                          id="react-autowhatever-1"
+                          role="listbox"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ReactModalPortal"
+              >
+                <div
+                  class="ReactModal__Overlay ReactModal__Overlay--after-open atom-overlay"
+                >
+                  <div
+                    aria-label="Command Palette"
+                    class="ReactModal__Content ReactModal__Content--after-open atom-modal"
+                    role="dialog"
+                    tabindex="-1"
+                  >
+                    <div>
+                      <div
+                        class="atom-header"
+                      />
+                      <div
                         aria-expanded="true"
                         aria-haspopup="listbox"
                         aria-owns="react-autowhatever-1"
@@ -33046,6 +33921,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   placeholder="Type a command"
                                   reactModalParentSelector="body"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -33250,6 +34126,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   placeholder="Type a command"
                                   reactModalParentSelector="body"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -33454,6 +34331,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   placeholder="Type a command"
                                   reactModalParentSelector="body"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -33659,6 +34537,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   placeholder="Type a command"
                                   reactModalParentSelector="body"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -33865,6 +34744,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   placeholder="Type a command"
                                   reactModalParentSelector="body"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -34069,6 +34949,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   placeholder="Type a command"
                                   reactModalParentSelector="body"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {
@@ -34273,6 +35154,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   placeholder="Type a command"
                                   reactModalParentSelector="body"
                                   renderCommand={null}
+                                  resetInputOnClose={false}
                                   showSpinnerOnSelect={true}
                                   suggestion={
                                     Object {

--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -236,11 +236,15 @@ class CommandPalette extends React.Component {
   }
 
   handleCloseModal() {
-    const { onRequestClose } = this.props;
+    const { resetInputOnClose, defaultInputValue, onRequestClose } = this.props;
+    const { value } = this.state;
+
     this.setState({
       showModal: false,
-      isLoading: false
+      isLoading: false,
+      value: resetInputOnClose ? defaultInputValue : value
     });
+
     return onRequestClose();
   }
 
@@ -374,6 +378,7 @@ CommandPalette.defaultProps = {
   onAfterOpen: noop,
   onRequestClose: noop,
   closeOnSelect: false,
+  resetInputOnClose: false,
   display: "modal",
   reactModalParentSelector: "body",
   renderCommand: null,
@@ -484,6 +489,10 @@ CommandPalette.propTypes = {
   /** closeOnSelect a boolean, when true selecting an item will immediately close the
    * command-palette  */
   closeOnSelect: PropTypes.bool,
+
+  /** resetInputOnClose a boolean which indicates whether to reset the user's query
+   * to `defaultInputValue` when the command palette closes. */
+  resetInputOnClose: PropTypes.bool,
 
   /** a selector compatible with querySelector. By default, the modal portal will be
    * appended to the document's body. You can choose a different parent element by

--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -398,7 +398,7 @@ CommandPalette.propTypes = {
     })
   ).isRequired,
 
-  /** maxDisplayed a number between 1 and 500 that determines the maxium number of
+  /** maxDisplayed a number between 1 and 500 that determines the maximum number of
    * commands that will be rendered on screen. Defaults to 7 */
   maxDisplayed(props, propName, componentName) {
     const { maxDisplayed } = props;
@@ -476,12 +476,12 @@ CommandPalette.propTypes = {
    * visible only to screen readers. */
   spinner: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 
-  /** showSpinnerOnSelect a boolean which displays a loading indicator immediatley after
+  /** showSpinnerOnSelect a boolean which displays a loading indicator immediately after
    * a command has been selected. When true the spinner is enabled when false the spinner
    * is disabled. */
   showSpinnerOnSelect: PropTypes.bool,
 
-  /** closeOnSelect a boolean, when true selecting an item will immendiately close the
+  /** closeOnSelect a boolean, when true selecting an item will immediately close the
    * command-palette  */
   closeOnSelect: PropTypes.bool,
 

--- a/src/command-palette.test.js
+++ b/src/command-palette.test.js
@@ -148,6 +148,41 @@ describe("props.header", () => {
   });
 });
 
+describe("props.resetInputOnClose", () => {
+  it("should not reset input by default", () => {
+    const commandPalette = mount(
+      <CommandPalette commands={mockCommands} open />
+    );
+
+    commandPalette
+      .find("input")
+      .simulate("change", { target: { value: "my query" } });
+
+    commandPalette.instance().handleCloseModal();
+    commandPalette.instance().handleOpenModal();
+    expect(commandPalette.state("value")).toEqual("my query");
+  });
+
+  it("should reset input to defaultInputValue when resetInputOnClose is set", () => {
+    const commandPalette = mount(
+      <CommandPalette
+        commands={mockCommands}
+        defaultInputValue="default"
+        open
+        resetInputOnClose
+      />
+    );
+
+    commandPalette
+      .find("input")
+      .simulate("change", { target: { value: "my query" } });
+
+    commandPalette.instance().handleCloseModal();
+    commandPalette.instance().handleOpenModal();
+    expect(commandPalette.state("value")).toEqual("default");
+  });
+});
+
 describe("props.renderCommand", () => {
   it("should render a custom command component", () => {
     const commandPalette = mount(

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -157,7 +157,7 @@ storiesOf("Command Palette", module)
     ),
     {
       info: {
-        text: `By default, react-command-palette will render the _suggestion.name_ for each command.  However, when passed a custom react component _renderCommand_ will display the command using any template you can imageine. See: https://github.com/asabaylus/react-command-palette/blob/master/examples/sampleAtomCommand.js`
+        text: `By default, react-command-palette will render the _suggestion.name_ for each command.  However, when passed a custom react component _renderCommand_ will display the command using any template you can imagine. See: https://github.com/asabaylus/react-command-palette/blob/master/examples/sampleAtomCommand.js`
       }
     }
   )

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -267,6 +267,9 @@ storiesOf("Command Palette", module)
   .add("with closeOnSelect", () => (
     <CommandPalette commands={commands} closeOnSelect open />
   ))
+  .add("with resetInputOnClose", () => (
+    <CommandPalette commands={commands} open resetInputOnClose />
+  ))
   .add("with custom placeholder", () => (
     <CommandPalette
       commands={commands}


### PR DESCRIPTION
Implements the enhancement discussed in https://github.com/asabaylus/react-command-palette/issues/454. I named the prop `resetInputOnClose` instead of `clearInputOnClose` to communicate that the value gets set to `defaultInputValue` rather than an empty string.