### PR TITLE
Introduce a globalHotKeys property

### DIFF
--- a/src/__snapshots__/command-palette.test.js.snap
+++ b/src/__snapshots__/command-palette.test.js.snap
@@ -84,6 +84,7 @@ exports[`Command List renders a command 1`] = `
   }
   defaultInputValue=""
   display="modal"
+  globalHotKeys={false}
   header={null}
   highlightFirstSuggestion={true}
   hotKeys="command+shift+p"
@@ -11035,6 +11036,7 @@ exports[`Command List renders a command 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -11247,6 +11249,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
   }
   defaultInputValue=""
   display="modal"
+  globalHotKeys={false}
   header={null}
   highlightFirstSuggestion={true}
   hotKeys="command+shift+p"
@@ -18008,6 +18011,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -18213,6 +18217,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -18418,6 +18423,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -18624,6 +18630,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -18831,6 +18838,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -19036,6 +19044,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -19241,6 +19250,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -19418,6 +19428,7 @@ exports[`props.display should not display the command palette in react-modal whe
   }
   defaultInputValue=""
   display="inline"
+  globalHotKeys={false}
   header={null}
   highlightFirstSuggestion={true}
   hotKeys="command+shift+p"
@@ -19908,6 +19919,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
+                        globalHotKeys={false}
                         header={null}
                         highlightFirstSuggestion={true}
                         hotKeys="command+shift+p"
@@ -20113,6 +20125,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
+                        globalHotKeys={false}
                         header={null}
                         highlightFirstSuggestion={true}
                         hotKeys="command+shift+p"
@@ -20318,6 +20331,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
+                        globalHotKeys={false}
                         header={null}
                         highlightFirstSuggestion={true}
                         hotKeys="command+shift+p"
@@ -20524,6 +20538,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
+                        globalHotKeys={false}
                         header={null}
                         highlightFirstSuggestion={true}
                         hotKeys="command+shift+p"
@@ -20731,6 +20746,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
+                        globalHotKeys={false}
                         header={null}
                         highlightFirstSuggestion={true}
                         hotKeys="command+shift+p"
@@ -20936,6 +20952,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
+                        globalHotKeys={false}
                         header={null}
                         highlightFirstSuggestion={true}
                         hotKeys="command+shift+p"
@@ -21141,6 +21158,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
+                        globalHotKeys={false}
                         header={null}
                         highlightFirstSuggestion={true}
                         hotKeys="command+shift+p"
@@ -21410,6 +21428,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
   }
   defaultInputValue=""
   display="modal"
+  globalHotKeys={false}
   header={null}
   highlightFirstSuggestion={true}
   hotKeys="command+shift+p"
@@ -26636,6 +26655,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -26842,6 +26862,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -27048,6 +27069,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -27255,6 +27277,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -27463,6 +27486,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -27669,6 +27693,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -27875,6 +27900,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -28054,6 +28080,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
   }
   defaultInputValue=""
   display="modal"
+  globalHotKeys={false}
   header={null}
   highlightFirstSuggestion={true}
   hotKeys="command+shift+p"
@@ -30673,6 +30700,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -30880,6 +30908,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -31087,6 +31116,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -31295,6 +31325,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -31504,6 +31535,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -31711,6 +31743,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -31918,6 +31951,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -32097,6 +32131,7 @@ exports[`props.theme should render a custom theme 1`] = `
   }
   defaultInputValue=""
   display="modal"
+  globalHotKeys={false}
   header="this is a command palette"
   highlightFirstSuggestion={true}
   hotKeys="command+shift+p"
@@ -35642,6 +35677,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -35849,6 +35885,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -36056,6 +36093,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -36264,6 +36302,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -36473,6 +36512,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -36680,6 +36720,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -36887,6 +36928,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  globalHotKeys={false}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"

--- a/src/__snapshots__/command-palette.test.js.snap
+++ b/src/__snapshots__/command-palette.test.js.snap
@@ -84,7 +84,6 @@ exports[`Command List renders a command 1`] = `
   }
   defaultInputValue=""
   display="modal"
-  globalHotKeys={false}
   header={null}
   highlightFirstSuggestion={true}
   hotKeys="command+shift+p"
@@ -11036,7 +11035,6 @@ exports[`Command List renders a command 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -11249,7 +11247,6 @@ exports[`Opening the palette displays the suggestion list 1`] = `
   }
   defaultInputValue=""
   display="modal"
-  globalHotKeys={false}
   header={null}
   highlightFirstSuggestion={true}
   hotKeys="command+shift+p"
@@ -18011,7 +18008,6 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -18217,7 +18213,6 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -18423,7 +18418,6 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -18630,7 +18624,6 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -18838,7 +18831,6 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -19044,7 +19036,6 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -19250,7 +19241,6 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -19428,7 +19418,6 @@ exports[`props.display should not display the command palette in react-modal whe
   }
   defaultInputValue=""
   display="inline"
-  globalHotKeys={false}
   header={null}
   highlightFirstSuggestion={true}
   hotKeys="command+shift+p"
@@ -19919,7 +19908,6 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
-                        globalHotKeys={false}
                         header={null}
                         highlightFirstSuggestion={true}
                         hotKeys="command+shift+p"
@@ -20125,7 +20113,6 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
-                        globalHotKeys={false}
                         header={null}
                         highlightFirstSuggestion={true}
                         hotKeys="command+shift+p"
@@ -20331,7 +20318,6 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
-                        globalHotKeys={false}
                         header={null}
                         highlightFirstSuggestion={true}
                         hotKeys="command+shift+p"
@@ -20538,7 +20524,6 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
-                        globalHotKeys={false}
                         header={null}
                         highlightFirstSuggestion={true}
                         hotKeys="command+shift+p"
@@ -20746,7 +20731,6 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
-                        globalHotKeys={false}
                         header={null}
                         highlightFirstSuggestion={true}
                         hotKeys="command+shift+p"
@@ -20952,7 +20936,6 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
-                        globalHotKeys={false}
                         header={null}
                         highlightFirstSuggestion={true}
                         hotKeys="command+shift+p"
@@ -21158,7 +21141,6 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
-                        globalHotKeys={false}
                         header={null}
                         highlightFirstSuggestion={true}
                         hotKeys="command+shift+p"
@@ -21428,7 +21410,6 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
   }
   defaultInputValue=""
   display="modal"
-  globalHotKeys={false}
   header={null}
   highlightFirstSuggestion={true}
   hotKeys="command+shift+p"
@@ -26655,7 +26636,6 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -26862,7 +26842,6 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -27069,7 +27048,6 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -27277,7 +27255,6 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -27486,7 +27463,6 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -27693,7 +27669,6 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -27900,7 +27875,6 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -28080,7 +28054,6 @@ exports[`props.renderCommand should render a custom command component 1`] = `
   }
   defaultInputValue=""
   display="modal"
-  globalHotKeys={false}
   header={null}
   highlightFirstSuggestion={true}
   hotKeys="command+shift+p"
@@ -30700,7 +30673,6 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -30908,7 +30880,6 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -31116,7 +31087,6 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -31325,7 +31295,6 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -31535,7 +31504,6 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -31743,7 +31711,6 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -31951,7 +31918,6 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header={null}
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -32131,7 +32097,6 @@ exports[`props.theme should render a custom theme 1`] = `
   }
   defaultInputValue=""
   display="modal"
-  globalHotKeys={false}
   header="this is a command palette"
   highlightFirstSuggestion={true}
   hotKeys="command+shift+p"
@@ -35677,7 +35642,6 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -35885,7 +35849,6 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -36093,7 +36056,6 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -36302,7 +36264,6 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -36512,7 +36473,6 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -36720,7 +36680,6 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"
@@ -36928,7 +36887,6 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  globalHotKeys={false}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
                                   hotKeys="command+shift+p"

--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -89,11 +89,10 @@ class CommandPalette extends React.Component {
     });
 
     // Use hot key to open command palette
-    const mousetrap = new Mousetrap();
     if (globalHotKeys) {
-      mousetrap.stopCallback = () => false;
+      Mousetrap.prototype.stopCallback = () => false;
     }
-    mousetrap.bind(hotKeys, () => {
+    Mousetrap.bind(hotKeys, () => {
       this.handleOpenModal();
       // prevent default which opens Chrome dev tools command palatte
       return false;
@@ -362,7 +361,6 @@ CommandPalette.defaultProps = {
   alwaysRenderCommands: true,
   placeholder: "Type a command",
   hotKeys: "command+shift+p",
-  globalHotKeys: false,
   defaultInputValue: "",
   header: null,
   highlightFirstSuggestion: true,

--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -89,10 +89,11 @@ class CommandPalette extends React.Component {
     });
 
     // Use hot key to open command palette
+    const mousetrap = new Mousetrap();
     if (globalHotKeys) {
-      Mousetrap.stopCallback = () => false;
+      mousetrap.stopCallback = () => false;
     }
-    Mousetrap.bind(hotKeys, () => {
+    mousetrap.bind(hotKeys, () => {
       this.handleOpenModal();
       // prevent default which opens Chrome dev tools command palatte
       return false;

--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -89,8 +89,10 @@ class CommandPalette extends React.Component {
     });
 
     // Use hot key to open command palette
-    const mousetrap = globalHotKeys ? Mousetrap.bindGlobal : Mousetrap.bind;
-    mousetrap(hotKeys, () => {
+    if (globalHotKeys) {
+      Mousetrap.stopCallback = () => false;
+    }
+    Mousetrap.bind(hotKeys, () => {
       this.handleOpenModal();
       // prevent default which opens Chrome dev tools command palatte
       return false;

--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -82,14 +82,15 @@ class CommandPalette extends React.Component {
   }
 
   componentDidMount() {
-    const { hotKeys, open, display } = this.props;
+    const { hotKeys, globalHotKeys, open, display } = this.props;
 
     this.setState({
       suggestions: this.fetchData()
     });
 
     // Use hot key to open command palette
-    Mousetrap.bind(hotKeys, () => {
+    const mousetrap = globalHotKeys ? Mousetrap.bindGlobal : Mousetrap.bind;
+    mousetrap(hotKeys, () => {
       this.handleOpenModal();
       // prevent default which opens Chrome dev tools command palatte
       return false;
@@ -358,6 +359,7 @@ CommandPalette.defaultProps = {
   alwaysRenderCommands: true,
   placeholder: "Type a command",
   hotKeys: "command+shift+p",
+  globalHotKeys: false,
   defaultInputValue: "",
   header: null,
   highlightFirstSuggestion: true,
@@ -419,6 +421,11 @@ CommandPalette.propTypes = {
     PropTypes.arrayOf(PropTypes.string),
     PropTypes.string
   ]),
+
+  /** When globalHotKeys={false}, any hotKeys provided will be ignored when keyboard
+   *  focus is inside of a text input or textarea. When globalHotKeys={true}, hotKeys
+   *  will trigger even inside of these inputs. */
+  globalHotKeys: PropTypes.bool,
 
   /** defaultInputValue a string that determines the value of the text in the input field.
    * By default the defaultInputValue is an empty string. */


### PR DESCRIPTION
By default, Mousetrap ignores hotkey bindings whenever keyboard events are coming from inside an input, select, contenteditable, or textarea element.

There is a way to suppress this behavior and force Mousetrap events to always trigger.

This PR adds a property to the CommandPalette props that can use this behavior.