### PR TITLE
Add shouldFocusAfterRender option to support changing focused element via command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ WAI-ARIA compliant React command palette like the one in Atom and Sublime
 
 ## Live Playground
 
-For examples of the command palette in action, go to the
+For examples of the command palette in action, go to the 
 
 [![Storybook](https://github.com/storybooks/brand/raw/master/badge/badge-storybook.svg?sanitize=true)](https://react-command-palette.js.org)
 
@@ -46,11 +46,11 @@ const commands = [{
     name: "Bar",
     command() {}
   }
-  ...
+  ... 
  ];
-
+ 
  ReactDOM.render(
-  <CommandPalette commands={commands} />,
+  <CommandPalette commands={commands} />, 
   document.getElementById('app'))
 ```
 
@@ -83,10 +83,10 @@ const commands = [{
     keys: ["name"], // default is "name"
 
     // other options may be freely configured
-    threshold: -Infinity,
+    threshold: -Infinity, 
     limit: 7,
-    allowTypo: true,
-    scoreFn: null
+    allowTypo: true, 
+    scoreFn: null 
   ```
 * ```onChange``` a function that's called when the input value changes. It returns two values: the current value of the input field followed by the users typed input. The query ignores keyboard navigation and clicks.
 
@@ -104,7 +104,7 @@ const commands = [{
     />
   ```
 
-* ```onHighlight``` a function that's called when the highlighted suggestion changes.
+* ```onHighlight``` a function that's called when the highlighted suggestion changes. 
 
   ```js
     <CommandPalette
@@ -201,7 +201,7 @@ Note: It is not called if _open_ is changed by other means. Passes through to th
   />
   ```
   see: https://github.com/moroshko/react-autosuggest#rendersuggestion-required.
-
+ 
   Note: the _suggestion.highlight_ will contain the rendered markup from [fuzzysort](farzher/fuzzysort#fuzzysorthighlightresult-openb-closeb), see the ```options``` prop. If the ```options``` prop contains an array of "keys" then then _suggestion.highlight_ will contain an array of matches, see: [fuzzysort advanced usage](https://github.com/farzher/fuzzysort#advanced-usage) or checkout the [sampleChromeCommand.js](examples/sampleChromeCommand.js)
 
   *Important:* _renderCommand_ must be a pure function (react-autosuggest, upon which this is based will optimize rendering performance based on this assumption).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ WAI-ARIA compliant React command palette like the one in Atom and Sublime
 
 ## Live Playground
 
-For examples of the command palette in action, go to the 
+For examples of the command palette in action, go to the
 
 [![Storybook](https://github.com/storybooks/brand/raw/master/badge/badge-storybook.svg?sanitize=true)](https://react-command-palette.js.org)
 
@@ -46,11 +46,11 @@ const commands = [{
     name: "Bar",
     command() {}
   }
-  ... 
+  ...
  ];
- 
+
  ReactDOM.render(
-  <CommandPalette commands={commands} />, 
+  <CommandPalette commands={commands} />,
   document.getElementById('app'))
 ```
 
@@ -83,10 +83,10 @@ const commands = [{
     keys: ["name"], // default is "name"
 
     // other options may be freely configured
-    threshold: -Infinity, 
+    threshold: -Infinity,
     limit: 7,
-    allowTypo: true, 
-    scoreFn: null 
+    allowTypo: true,
+    scoreFn: null
   ```
 * ```onChange``` a function that's called when the input value changes. It returns two values: the current value of the input field followed by the users typed input. The query ignores keyboard navigation and clicks.
 
@@ -104,7 +104,7 @@ const commands = [{
     />
   ```
 
-* ```onHighlight``` a function that's called when the highlighted suggestion changes. 
+* ```onHighlight``` a function that's called when the highlighted suggestion changes.
 
   ```js
     <CommandPalette
@@ -153,6 +153,8 @@ Note: It is not called if _open_ is changed by other means. Passes through to th
     />
   ```
 
+* ```shouldReturnFocusAfterClose``` a boolean indicate if the modal should restore focus to the element that had focus prior to its display.
+
 * ```commands``` appears in the command palette. For each command in the array the object must have a _name_ and a _command_. The _name_ is a user friendly string that will be display to the user. The command is a function that will be executed when the user clicks or presses the enter key. Commands may also include custom properties where "this" will be bound to the command, for example:
 
   ```js
@@ -199,7 +201,7 @@ Note: It is not called if _open_ is changed by other means. Passes through to th
   />
   ```
   see: https://github.com/moroshko/react-autosuggest#rendersuggestion-required.
- 
+
   Note: the _suggestion.highlight_ will contain the rendered markup from [fuzzysort](farzher/fuzzysort#fuzzysorthighlightresult-openb-closeb), see the ```options``` prop. If the ```options``` prop contains an array of "keys" then then _suggestion.highlight_ will contain an array of matches, see: [fuzzysort advanced usage](https://github.com/farzher/fuzzysort#advanced-usage) or checkout the [sampleChromeCommand.js](examples/sampleChromeCommand.js)
 
   *Important:* _renderCommand_ must be a pure function (react-autosuggest, upon which this is based will optimize rendering performance based on this assumption).

--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -305,7 +305,7 @@ class CommandPalette extends React.Component {
 
   renderModalCommandPalette() {
     const { showModal } = this.state;
-    const { trigger, theme, reactModalParentSelector } = this.props;
+    const { trigger, theme, reactModalParentSelector, shouldReturnFocusAfterClose } = this.props;
     return (
       <div className="react-command-palette">
         <PaletteTrigger
@@ -321,6 +321,7 @@ class CommandPalette extends React.Component {
           }
           onAfterOpen={this.afterOpenModal}
           onRequestClose={this.handleCloseModal}
+          shouldReturnFocusAfterClose={shouldReturnFocusAfterClose}
           className={theme.modal}
           overlayClassName={theme.overlay}
           contentLabel="Command Palette"

--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -305,7 +305,12 @@ class CommandPalette extends React.Component {
 
   renderModalCommandPalette() {
     const { showModal } = this.state;
-    const { trigger, theme, reactModalParentSelector, shouldReturnFocusAfterClose } = this.props;
+    const {
+      trigger,
+      theme,
+      reactModalParentSelector,
+      shouldReturnFocusAfterClose,
+    } = this.props;
     return (
       <div className="react-command-palette">
         <PaletteTrigger
@@ -484,6 +489,11 @@ CommandPalette.propTypes = {
    * a command has been selected. When true the spinner is enabled when false the spinner
    * is disabled. */
   showSpinnerOnSelect: PropTypes.bool,
+
+  /**
+   * shouldReturnFocusAfterClose a boolean indicate if the modal should restore focus to
+   * the element that had focus prior to its display. */
+  shouldReturnFocusAfterClose: PropTypes.bool,
 
   /** closeOnSelect a boolean, when true selecting an item will immediately close the
    * command-palette  */

--- a/src/command-palette.shouldFocusAfterRender.test.js
+++ b/src/command-palette.shouldFocusAfterRender.test.js
@@ -26,8 +26,10 @@ describe('props.shouldReturnFocusAfterClose', () => {
   it("should return to focused element after close if true", async () => {
     const focusedElement = global.document.createElement("button");
     focusedElement.setAttribute("id", "button");
+    const focusedElement2 = global.document.createElement("button");
     const body = global.document.querySelector("body");
     body.appendChild(focusedElement);
+    body.appendChild(focusedElement2);
     focusedElement.focus()
     expect(global.document.activeElement).toBe(global.document.querySelector('#button'))
     const commandPalette = mount(<CommandPalette
@@ -36,9 +38,11 @@ describe('props.shouldReturnFocusAfterClose', () => {
     commandPalette.instance().handleOpenModal();
     expect(global.document.activeElement).toBe(global.document.querySelector('input'))
     expect(commandPalette.state("showModal")).toEqual(true);
-    commandPalette.instance().handleCloseModal();
-
     expect(global.document.activeElement).toBe(global.document.querySelector('input'))
+    // Change focus during command palette open
+    focusedElement2.focus()
+    expect(global.document.activeElement).toBe(focusedElement2)
+    commandPalette.instance().handleCloseModal();
     await new Promise((r) => setTimeout(r, 50));
     expect(global.document.activeElement).toBe(global.document.querySelector('#button'));
   });

--- a/src/command-palette.shouldFocusAfterRender.test.js
+++ b/src/command-palette.shouldFocusAfterRender.test.js
@@ -13,14 +13,15 @@ import mockCommands from "./__mocks__/commands";
 // React 16 Enzyme adapter
 Enzyme.configure({ adapter: new Adapter() });
 
-// We have to put this in a separate file. Otherwise, the global.document.activeElement
-// will be reseted by other test suite to null which we can't easily validate the return focused element.
-describe('props.shouldReturnFocusAfterClose', () => {
+// We have to put this in a separate file. Otherwise, the document.activeElement
+// will be reseted by other test suite to null which we can't easily
+// validate the return focused element.
+describe("props.shouldReturnFocusAfterClose", () => {
   beforeEach(() => {
-    global.document.body.innerHTML = '';
+    global.document.body.innerHTML = "";
   });
   afterEach(() => {
-    global.document.body.innerHTML = '';
+    global.document.body.innerHTML = "";
   });
 
   it("should return to focused element after close if true", async () => {
@@ -30,21 +31,29 @@ describe('props.shouldReturnFocusAfterClose', () => {
     const body = global.document.querySelector("body");
     body.appendChild(focusedElement);
     body.appendChild(focusedElement2);
-    focusedElement.focus()
-    expect(global.document.activeElement).toBe(global.document.querySelector('#button'))
-    const commandPalette = mount(<CommandPalette
-      commands={mockCommands}
-      shouldReturnFocusAfterClose={true} />);
+    focusedElement.focus();
+    expect(global.document.activeElement).toBe(
+      global.document.querySelector("#button")
+    );
+    const commandPalette = mount(
+      <CommandPalette commands={mockCommands} shouldReturnFocusAfterClose />
+    );
     commandPalette.instance().handleOpenModal();
-    expect(global.document.activeElement).toBe(global.document.querySelector('input'))
+    expect(global.document.activeElement).toBe(
+      global.document.querySelector("input")
+    );
     expect(commandPalette.state("showModal")).toEqual(true);
-    expect(global.document.activeElement).toBe(global.document.querySelector('input'))
+    expect(global.document.activeElement).toBe(
+      global.document.querySelector("input")
+    );
     // Change focus during command palette open
-    focusedElement2.focus()
-    expect(global.document.activeElement).toBe(focusedElement2)
+    focusedElement2.focus();
+    expect(global.document.activeElement).toBe(focusedElement2);
     commandPalette.instance().handleCloseModal();
     await new Promise((r) => setTimeout(r, 50));
-    expect(global.document.activeElement).toBe(global.document.querySelector('#button'));
+    expect(global.document.activeElement).toBe(
+      global.document.querySelector("#button")
+    );
   });
 
   it("should not return to focused element after close if false", async () => {
@@ -52,16 +61,25 @@ describe('props.shouldReturnFocusAfterClose', () => {
     focusedElement.setAttribute("id", "button");
     const body = global.document.querySelector("body");
     body.appendChild(focusedElement);
-    focusedElement.focus()
-    expect(global.document.activeElement).toBe(global.document.querySelector('#button'))
-    const commandPalette = mount(<CommandPalette
-      commands={mockCommands}
-      shouldReturnFocusAfterClose={false} />);
+    focusedElement.focus();
+    expect(global.document.activeElement).toBe(
+      global.document.querySelector("#button")
+    );
+    const commandPalette = mount(
+      <CommandPalette
+        commands={mockCommands}
+        shouldReturnFocusAfterClose={false}
+      />
+    );
     commandPalette.instance().handleOpenModal();
-    expect(global.document.activeElement).toBe(global.document.querySelector('input'))
+    expect(global.document.activeElement).toBe(
+      global.document.querySelector("input")
+    );
     expect(commandPalette.state("showModal")).toEqual(true);
     commandPalette.instance().handleCloseModal();
     await new Promise((r) => setTimeout(r, 50));
-    expect(global.document.activeElement).toBe(global.document.querySelector('body'))
+    expect(global.document.activeElement).toBe(
+      global.document.querySelector("body")
+    );
   });
 });

--- a/src/command-palette.shouldFocusAfterRender.test.js
+++ b/src/command-palette.shouldFocusAfterRender.test.js
@@ -1,0 +1,63 @@
+/* eslint-disable no-console */
+/*  eslint
+  no-unused-vars: ["error", { "varsIgnorePattern": "^renderer$" }],
+  "function-paren-newline":0,
+  no-new:0 */
+
+import React from "react";
+import Enzyme, { mount } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+import CommandPalette from "./command-palette";
+import mockCommands from "./__mocks__/commands";
+
+// React 16 Enzyme adapter
+Enzyme.configure({ adapter: new Adapter() });
+
+// We have to put this in a separate file. Otherwise, the global.document.activeElement
+// will be reseted by other test suite to null which we can't easily validate the return focused element.
+describe('props.shouldReturnFocusAfterClose', () => {
+  beforeEach(() => {
+    global.document.body.innerHTML = '';
+  });
+  afterEach(() => {
+    global.document.body.innerHTML = '';
+  });
+
+  it("should return to focused element after close if true", async () => {
+    const focusedElement = global.document.createElement("button");
+    focusedElement.setAttribute("id", "button");
+    const body = global.document.querySelector("body");
+    body.appendChild(focusedElement);
+    focusedElement.focus()
+    expect(global.document.activeElement).toBe(global.document.querySelector('#button'))
+    const commandPalette = mount(<CommandPalette
+      commands={mockCommands}
+      shouldReturnFocusAfterClose={true} />);
+    commandPalette.instance().handleOpenModal();
+    expect(global.document.activeElement).toBe(global.document.querySelector('input'))
+    expect(commandPalette.state("showModal")).toEqual(true);
+    commandPalette.instance().handleCloseModal();
+
+    expect(global.document.activeElement).toBe(global.document.querySelector('input'))
+    await new Promise((r) => setTimeout(r, 50));
+    expect(global.document.activeElement).toBe(global.document.querySelector('#button'));
+  });
+
+  it("should not return to focused element after close if false", async () => {
+    const focusedElement = global.document.createElement("button");
+    focusedElement.setAttribute("id", "button");
+    const body = global.document.querySelector("body");
+    body.appendChild(focusedElement);
+    focusedElement.focus()
+    expect(global.document.activeElement).toBe(global.document.querySelector('#button'))
+    const commandPalette = mount(<CommandPalette
+      commands={mockCommands}
+      shouldReturnFocusAfterClose={false} />);
+    commandPalette.instance().handleOpenModal();
+    expect(global.document.activeElement).toBe(global.document.querySelector('input'))
+    expect(commandPalette.state("showModal")).toEqual(true);
+    commandPalette.instance().handleCloseModal();
+    await new Promise((r) => setTimeout(r, 50));
+    expect(global.document.activeElement).toBe(global.document.querySelector('body'))
+  });
+});


### PR DESCRIPTION
The current behavior is always to return the focus state to the last focused element before open the command palette. However, it breaks the expectation if any command will change the focused element. With the current setup, the focused element changes will be:

> LastFocusedElement -> Command Palette Input -> TargetFocusElement (via a command) -> LastFocusedElement (via close of react-modal).


This PR adds the `shouldFocusAfterRender` which will be passed to react-modal so that the focused element changes will be if users pass `shouldFocusAfterRender={true}`:

> LastFocusedElement -> Command Palette Input -> TargetFocusElement (via a command) -> TargetFocusElement (no focused element change)