### PR TITLE
Fix the `onHighlight` example in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ const commands = [{
   ```js
     <CommandPalette
       commands={commands}
-      onSelect={suggestion => {
+      onHighlight={suggestion => {
         console.log(`A suggested command was highlighted: \n
         ${JSON.stringify(suggestion)}
         `);


### PR DESCRIPTION
Update the `onHighlight` example in the docs to:
```
<CommandPalette
    commands={commands}
    onHighlight={suggestion => {
      console.log(`A suggested command was highlighted: \n
      ${JSON.stringify(suggestion)}
      `);
    }}
  />
```
Instead of:
```
<CommandPalette
    commands={commands}
    onSelect={suggestion => {
      console.log(`A suggested command was highlighted: \n
      ${JSON.stringify(suggestion)}
      `);
    }}
  />
```