### PR TITLE
Closes #586: cleanup duplicate getSuggestionValue

### DIFF
--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -294,7 +294,6 @@ class CommandPalette extends React.Component {
           onSuggestionSelected={this.onSuggestionSelected}
           onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
           onSuggestionsClearRequested={this.onSuggestionsClearRequested}
-          getSuggestionValue={getSuggestionValue}
           renderSuggestion={this.commandTemplate}
           inputProps={this.defaultInputProps(value)}
           theme={theme}


### PR DESCRIPTION
Removes redundant `getSuggestionValue` prop from react-autosuggest component. No known impact