### PR TITLE
Closes #588: Add filterSearchQuery prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,23 @@ const commands = [{
     allowTypo: true, 
     scoreFn: null 
   ```
+
+* ```filterInput``` a function that filters searched input. If this prop is not used the default behavior will search the input exactly entered otherwise whatever gets returned for each suggestion is the text that will be searched. You might use this filter out extraneous characters such as ">" or "?" like VS Code does for _action_ keys, ex:
+  ```js
+    <CommandPalette
+      commands={commands}
+      placeholder="Try typing '?st', '>st' or 'st'"
+      defaultInputValue=">"
+      filterInput={ (inputValue) => {
+        // strip action keys from input before searching commands, ex:
+        // "?something" or ">something" should search "something"
+        // TODO: pass "/>|\?/g" as a prop
+        return inputValue.replace(/^(>|\?)/g, '');
+      }}
+      open
+    />
+  ```
+
 * ```onChange``` a _function_ that's called when the input value changes. It returns two values: the current value of the input field followed by the users typed input. The query ignores keyboard navigation and clicks.
 
   ```js

--- a/README.md
+++ b/README.md
@@ -90,15 +90,15 @@ const commands = [{
     scoreFn: null 
   ```
 
-* ```filterInput``` a function that filters searched input. If this prop is not used the default behavior will search the input exactly entered otherwise whatever gets returned for each suggestion is the text that will be searched. You might use this filter out extraneous characters such as ">" or "?" like VS Code does for _action_ keys, ex:
+* ```filterSearchQuery``` a function that filters searched input. If this prop is not used the default behavior will search using the input exactly as it was entered by the user. Otherwise whatever gets returned by your function is the text that will be searched. You might use this filter out extraneous characters such as ">" or "?" like VS Code does for _action_ keys, ex:
   ```js
     <CommandPalette
       commands={commands}
       placeholder="Try typing '?st', '>st' or 'st'"
       defaultInputValue=">"
-      filterInput={ (inputValue) => {
-        // strip action keys from input before searching commands, ex:
-        // "?something" or ">something" should search "something"
+      filterSearchQuery={ inputValue => {
+        // strip action keys "? or >" from input before searching commands, ex:
+        // "?something" or ">something" should search using "something" as the query
         return inputValue.replace(/^(>|\?)/g, '');
       }}
       open

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ const commands = [{
     scoreFn: null 
   ```
 
-* ```filterSearchQuery``` a function that filters searched input. If this prop is not used the default behavior will search using the input exactly as it was entered by the user. Otherwise whatever gets returned by your function is the text that will be searched. You might use this filter out extraneous characters such as ">" or "?" like VS Code does for _action_ keys, ex:
+* ```filterSearchQuery``` a _function_ that filters searched input. If this prop is not used the default behavior will search using the input exactly as it was entered by the user. Otherwise whatever gets returned by your function is the text that will be searched. You might use this filter out extraneous characters such as ">" or "?" like VS Code does for _action_ keys, ex:
   ```js
     <CommandPalette
       commands={commands}

--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ const commands = [{
       filterInput={ (inputValue) => {
         // strip action keys from input before searching commands, ex:
         // "?something" or ">something" should search "something"
-        // TODO: pass "/>|\?/g" as a prop
         return inputValue.replace(/^(>|\?)/g, '');
       }}
       open

--- a/src/__snapshots__/command-palette.test.js.snap
+++ b/src/__snapshots__/command-palette.test.js.snap
@@ -84,6 +84,7 @@ exports[`Command List renders a command 1`] = `
   }
   defaultInputValue=""
   display="modal"
+  filterInput={[Function]}
   getSuggestionValue={[Function]}
   header={null}
   highlightFirstSuggestion={true}
@@ -11447,6 +11448,7 @@ exports[`Command List renders a command 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -11661,6 +11663,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
   }
   defaultInputValue=""
   display="modal"
+  filterInput={[Function]}
   getSuggestionValue={[Function]}
   header={null}
   highlightFirstSuggestion={true}
@@ -18794,6 +18797,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -19001,6 +19005,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -19208,6 +19213,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -19416,6 +19422,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -19625,6 +19632,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -19832,6 +19840,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -20039,6 +20048,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -20218,6 +20228,7 @@ exports[`props.display should not display the command palette in react-modal whe
   }
   defaultInputValue=""
   display="inline"
+  filterInput={[Function]}
   getSuggestionValue={[Function]}
   header={null}
   highlightFirstSuggestion={true}
@@ -20712,6 +20723,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
+                        filterInput={[Function]}
                         getSuggestionValue={[Function]}
                         header={null}
                         highlightFirstSuggestion={true}
@@ -20919,6 +20931,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
+                        filterInput={[Function]}
                         getSuggestionValue={[Function]}
                         header={null}
                         highlightFirstSuggestion={true}
@@ -21126,6 +21139,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
+                        filterInput={[Function]}
                         getSuggestionValue={[Function]}
                         header={null}
                         highlightFirstSuggestion={true}
@@ -21334,6 +21348,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
+                        filterInput={[Function]}
                         getSuggestionValue={[Function]}
                         header={null}
                         highlightFirstSuggestion={true}
@@ -21543,6 +21558,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
+                        filterInput={[Function]}
                         getSuggestionValue={[Function]}
                         header={null}
                         highlightFirstSuggestion={true}
@@ -21750,6 +21766,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
+                        filterInput={[Function]}
                         getSuggestionValue={[Function]}
                         header={null}
                         highlightFirstSuggestion={true}
@@ -21957,6 +21974,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
+                        filterInput={[Function]}
                         getSuggestionValue={[Function]}
                         header={null}
                         highlightFirstSuggestion={true}
@@ -22228,6 +22246,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
   }
   defaultInputValue=""
   display="modal"
+  filterInput={[Function]}
   getSuggestionValue={[Function]}
   header={null}
   highlightFirstSuggestion={true}
@@ -27816,6 +27835,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -28024,6 +28044,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -28232,6 +28253,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -28441,6 +28463,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -28651,6 +28674,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -28859,6 +28883,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -29067,6 +29092,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -29248,6 +29274,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
   }
   defaultInputValue=""
   display="modal"
+  filterInput={[Function]}
   getSuggestionValue={[Function]}
   header={null}
   highlightFirstSuggestion={true}
@@ -31901,6 +31928,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -32110,6 +32138,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -32319,6 +32348,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -32529,6 +32559,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -32740,6 +32771,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -32949,6 +32981,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -33158,6 +33191,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -33339,6 +33373,7 @@ exports[`props.theme should render a custom theme 1`] = `
   }
   defaultInputValue=""
   display="modal"
+  filterInput={[Function]}
   getSuggestionValue={[Function]}
   header="this is a command palette"
   highlightFirstSuggestion={true}
@@ -36924,6 +36959,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
@@ -37133,6 +37169,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
@@ -37342,6 +37379,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
@@ -37552,6 +37590,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
@@ -37763,6 +37802,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
@@ -37972,6 +38012,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
@@ -38181,6 +38222,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
+                                  filterInput={[Function]}
                                   getSuggestionValue={[Function]}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}

--- a/src/__snapshots__/command-palette.test.js.snap
+++ b/src/__snapshots__/command-palette.test.js.snap
@@ -84,7 +84,7 @@ exports[`Command List renders a command 1`] = `
   }
   defaultInputValue=""
   display="modal"
-  filterInput={[Function]}
+  filterSearchQuery={[Function]}
   getSuggestionValue={[Function]}
   header={null}
   highlightFirstSuggestion={true}
@@ -11460,7 +11460,7 @@ exports[`Command List renders a command 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -11675,7 +11675,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
   }
   defaultInputValue=""
   display="modal"
-  filterInput={[Function]}
+  filterSearchQuery={[Function]}
   getSuggestionValue={[Function]}
   header={null}
   highlightFirstSuggestion={true}
@@ -18821,7 +18821,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -19029,7 +19029,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -19237,7 +19237,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -19446,7 +19446,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -19656,7 +19656,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -19864,7 +19864,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -20072,7 +20072,7 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -20252,7 +20252,7 @@ exports[`props.display should not display the command palette in react-modal whe
   }
   defaultInputValue=""
   display="inline"
-  filterInput={[Function]}
+  filterSearchQuery={[Function]}
   getSuggestionValue={[Function]}
   header={null}
   highlightFirstSuggestion={true}
@@ -20747,7 +20747,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
-                        filterInput={[Function]}
+                        filterSearchQuery={[Function]}
                         getSuggestionValue={[Function]}
                         header={null}
                         highlightFirstSuggestion={true}
@@ -20955,7 +20955,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
-                        filterInput={[Function]}
+                        filterSearchQuery={[Function]}
                         getSuggestionValue={[Function]}
                         header={null}
                         highlightFirstSuggestion={true}
@@ -21163,7 +21163,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
-                        filterInput={[Function]}
+                        filterSearchQuery={[Function]}
                         getSuggestionValue={[Function]}
                         header={null}
                         highlightFirstSuggestion={true}
@@ -21372,7 +21372,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
-                        filterInput={[Function]}
+                        filterSearchQuery={[Function]}
                         getSuggestionValue={[Function]}
                         header={null}
                         highlightFirstSuggestion={true}
@@ -21582,7 +21582,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
-                        filterInput={[Function]}
+                        filterSearchQuery={[Function]}
                         getSuggestionValue={[Function]}
                         header={null}
                         highlightFirstSuggestion={true}
@@ -21790,7 +21790,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
-                        filterInput={[Function]}
+                        filterSearchQuery={[Function]}
                         getSuggestionValue={[Function]}
                         header={null}
                         highlightFirstSuggestion={true}
@@ -21998,7 +21998,7 @@ exports[`props.display should not display the command palette in react-modal whe
                         }
                         defaultInputValue=""
                         display="inline"
-                        filterInput={[Function]}
+                        filterSearchQuery={[Function]}
                         getSuggestionValue={[Function]}
                         header={null}
                         highlightFirstSuggestion={true}
@@ -22270,7 +22270,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
   }
   defaultInputValue=""
   display="modal"
-  filterInput={[Function]}
+  filterSearchQuery={[Function]}
   getSuggestionValue={[Function]}
   header={null}
   highlightFirstSuggestion={true}
@@ -27871,7 +27871,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -28080,7 +28080,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -28289,7 +28289,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -28499,7 +28499,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -28710,7 +28710,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -28919,7 +28919,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -29128,7 +29128,7 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -29310,7 +29310,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
   }
   defaultInputValue=""
   display="modal"
-  filterInput={[Function]}
+  filterSearchQuery={[Function]}
   getSuggestionValue={[Function]}
   header={null}
   highlightFirstSuggestion={true}
@@ -31964,7 +31964,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -32174,7 +32174,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -32384,7 +32384,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -32595,7 +32595,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -32807,7 +32807,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -33017,7 +33017,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -33227,7 +33227,7 @@ exports[`props.renderCommand should render a custom command component 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header={null}
                                   highlightFirstSuggestion={true}
@@ -33409,7 +33409,7 @@ exports[`props.theme should render a custom theme 1`] = `
   }
   defaultInputValue=""
   display="modal"
-  filterInput={[Function]}
+  filterSearchQuery={[Function]}
   getSuggestionValue={[Function]}
   header="this is a command palette"
   highlightFirstSuggestion={true}
@@ -37007,7 +37007,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
@@ -37217,7 +37217,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
@@ -37427,7 +37427,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
@@ -37638,7 +37638,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
@@ -37850,7 +37850,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
@@ -38060,7 +38060,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}
@@ -38270,7 +38270,7 @@ exports[`props.theme should render a custom theme 1`] = `
                                   }
                                   defaultInputValue=""
                                   display="modal"
-                                  filterInput={[Function]}
+                                  filterSearchQuery={[Function]}
                                   getSuggestionValue={[Function]}
                                   header="this is a command palette"
                                   highlightFirstSuggestion={true}

--- a/src/__snapshots__/command-palette.test.js.snap
+++ b/src/__snapshots__/command-palette.test.js.snap
@@ -1413,6 +1413,12 @@ exports[`Command List renders a command 1`] = `
           </div>
           <div
             class="ReactModalPortal"
+          />
+          <div
+            class="ReactModalPortal"
+          />
+          <div
+            class="ReactModalPortal"
           >
             <div
               class="ReactModal__Overlay ReactModal__Overlay--after-open chrome-overlay"
@@ -6892,6 +6898,12 @@ exports[`Command List renders a command 1`] = `
                   </div>
                 </div>
               </div>
+              <div
+                class="ReactModalPortal"
+              />
+              <div
+                class="ReactModalPortal"
+              />
               <div
                 class="ReactModalPortal"
               >
@@ -12991,6 +13003,12 @@ exports[`Opening the palette displays the suggestion list 1`] = `
           </div>
           <div
             class="ReactModalPortal"
+          />
+          <div
+            class="ReactModalPortal"
+          />
+          <div
+            class="ReactModalPortal"
           >
             <div
               class="ReactModal__Overlay ReactModal__Overlay--after-open chrome-overlay"
@@ -16345,6 +16363,12 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                   </div>
                 </div>
               </div>
+              <div
+                class="ReactModalPortal"
+              />
+              <div
+                class="ReactModalPortal"
+              />
               <div
                 class="ReactModalPortal"
               >
@@ -23575,6 +23599,12 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
           </div>
           <div
             class="ReactModalPortal"
+          />
+          <div
+            class="ReactModalPortal"
+          />
+          <div
+            class="ReactModalPortal"
           >
             <div
               class="ReactModal__Overlay ReactModal__Overlay--after-open chrome-overlay"
@@ -26156,6 +26186,12 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                   </div>
                 </div>
               </div>
+              <div
+                class="ReactModalPortal"
+              />
+              <div
+                class="ReactModalPortal"
+              />
               <div
                 class="ReactModalPortal"
               >
@@ -34702,6 +34738,12 @@ exports[`props.theme should render a custom theme 1`] = `
           </div>
           <div
             class="ReactModalPortal"
+          />
+          <div
+            class="ReactModalPortal"
+          />
+          <div
+            class="ReactModalPortal"
           >
             <div
               class="ReactModal__Overlay ReactModal__Overlay--after-open chrome-overlay"
@@ -36281,6 +36323,12 @@ exports[`props.theme should render a custom theme 1`] = `
                   </div>
                 </div>
               </div>
+              <div
+                class="ReactModalPortal"
+              />
+              <div
+                class="ReactModalPortal"
+              />
               <div
                 class="ReactModalPortal"
               >

--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -159,9 +159,9 @@ class CommandPalette extends React.Component {
   // Autosuggest will call this function every time you need to update suggestions.
   // You already implemented this logic above, so just use it.
   onSuggestionsFetchRequested({ value }) {
-    const { options, filterInput } = this.props;
+    const { options, filterSearchQuery } = this.props;
     this.setState({
-      suggestions: getSuggestions(value, this.allCommands, options, filterInput),
+      suggestions: getSuggestions(value, this.allCommands, options, filterSearchQuery),
     });
   }
 
@@ -369,7 +369,7 @@ CommandPalette.defaultProps = {
   highlightFirstSuggestion: true,
   maxDisplayed: 7,
   options: fuzzysortOptions,
-  filterInput: (inputValue) => inputValue,
+  filterSearchQuery: (inputValue) => inputValue,
   onChange: noop,
   onHighlight: noop,
   onSelect: noop,
@@ -446,9 +446,9 @@ CommandPalette.propTypes = {
    * (https://github.com/farzher/fuzzysort#options) */
   options: PropTypes.object,
 
-  /** a function that filters input before searching it with fuzzysort. If this prop is not 
-   * used the default behavior will search the input exactly entered */
-  filterInput: PropTypes.func,
+  /** a function that filters the search query. If this prop is not used the default 
+   * behavior will search the input exactly entered */
+  filterSearchQuery: PropTypes.func,
 
   /** open a boolean, when set to true it forces the command palette to be displayed.
    * Defaults to "false". */

--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -446,8 +446,8 @@ CommandPalette.propTypes = {
    * (https://github.com/farzher/fuzzysort#options) */
   options: PropTypes.object,
 
-  /** a function that filters out characters from input that you don't need to search.
-   * if this prop is not used the default behavior will search the input exactly entered */
+  /** a function that filters input before searching it with fuzzysort. If this prop is not 
+   * used the default behavior will search the input exactly entered */
   filterInput: PropTypes.func,
 
   /** open a boolean, when set to true it forces the command palette to be displayed.

--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -159,9 +159,9 @@ class CommandPalette extends React.Component {
   // Autosuggest will call this function every time you need to update suggestions.
   // You already implemented this logic above, so just use it.
   onSuggestionsFetchRequested({ value }) {
-    const { options } = this.props;
+    const { options, filterInput } = this.props;
     this.setState({
-      suggestions: getSuggestions(value, this.allCommands, options),
+      suggestions: getSuggestions(value, this.allCommands, options, filterInput),
     });
   }
 
@@ -369,6 +369,7 @@ CommandPalette.defaultProps = {
   highlightFirstSuggestion: true,
   maxDisplayed: 7,
   options: fuzzysortOptions,
+  filterInput: (inputValue) => inputValue,
   onChange: noop,
   onHighlight: noop,
   onSelect: noop,
@@ -444,6 +445,10 @@ CommandPalette.propTypes = {
   /** options controls how fuzzy search is configured see [fuzzysort options]
    * (https://github.com/farzher/fuzzysort#options) */
   options: PropTypes.object,
+
+  /** a function that filters out characters from input that you don't need to search.
+   * if this prop is not used the default behavior will search the input exactly entered */
+  filterInput: PropTypes.func,
 
   /** open a boolean, when set to true it forces the command palette to be displayed.
    * Defaults to "false". */

--- a/src/command-palette.test.js
+++ b/src/command-palette.test.js
@@ -210,6 +210,33 @@ describe("props.defaultInputValue", () => {
   });
 });
 
+describe("props.inputFilter", () => {
+  it(`should filter input before sending it to fuzzysearch`, () => {
+    const commandPalette = mount(
+      <CommandPalette
+      commands={mockCommands}
+      filterInput={ inputValue => {
+        return inputValue.replace(/^(>|\?)/g, '');
+      }}
+      open
+    />);
+    commandPalette.find("input").simulate("change", { target: { value: ">st" } });
+    expect(commandPalette.find(".item").length).toEqual(2);
+    expect(commandPalette.find(".item").at(0).text()).toBe("Stop All Data Imports");
+    expect(commandPalette.find(".item").at(1).text()).toBe("Start All Data Imports");
+    commandPalette.unmount();
+  });
+
+  it(`should send the users input exactly as entered to fuzzysort by default`, () => {
+    const commandPalette = mount(
+      <CommandPalette commands={mockCommands} open />);
+    // return all commands because the string '>st' dosn't match the mockCommands
+    commandPalette.find("input").simulate("change", { target: { value: ">s" } });
+    expect(commandPalette.find(".item").length).toEqual(7);
+    commandPalette.unmount();
+  });
+});
+
 describe("props.theme", () => {
   it("should render a custom theme", () => {
     const commandPalette = mount(

--- a/src/command-palette.test.js
+++ b/src/command-palette.test.js
@@ -215,7 +215,7 @@ describe("props.inputFilter", () => {
     const commandPalette = mount(
       <CommandPalette
       commands={mockCommands}
-      filterInput={ inputValue => {
+      filterSearchQuery={ inputValue => {
         return inputValue.replace(/^(>|\?)/g, '');
       }}
       open

--- a/src/index.stories.js
+++ b/src/index.stories.js
@@ -313,7 +313,7 @@ storiesOf("Command Palette", module)
       />
     );
   })
-  .add("filterSearch", () => (
+  .add("filterInput", () => (
     <CommandPalette
       commands={commands}
       placeholder="Try typing '?st', '>st' or 'st'"

--- a/src/index.stories.js
+++ b/src/index.stories.js
@@ -313,6 +313,20 @@ storiesOf("Command Palette", module)
       />
     );
   })
+  .add("filterSearch", () => (
+    <CommandPalette
+      commands={commands}
+      placeholder="Try typing '?st', '>st' or 'st'"
+      defaultInputValue=">"
+      filterInput={ (inputValue) => {
+        // strip action keys from input before searching commands, ex:
+        // "?something" or ">something" should search "something"
+        // TODO: pass "/>|\?/g" as a prop
+        return inputValue.replace(/^(>|\?)/g, '');
+      }}
+      open
+    />
+  ))
   .add("with multiple highlights", () => {
     const opts = {
       keys: ["name", "category"]

--- a/src/index.stories.js
+++ b/src/index.stories.js
@@ -313,12 +313,12 @@ storiesOf("Command Palette", module)
       />
     );
   })
-  .add("filterInput", () => (
+  .add("filterSearchQuery", () => (
     <CommandPalette
       commands={commands}
       placeholder="Try typing '?st', '>st' or 'st'"
       defaultInputValue=">"
-      filterInput={ (inputValue) => {
+      filterSearchQuery={ inputValue => {
         // strip action keys from input before searching commands, ex:
         // "?something" or ">something" should search "something"
         // TODO: pass "/>|\?/g" as a prop

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -24,8 +24,18 @@ function formatSuggestions(filteredSuggestions) {
   });
 }
 
+function filterFuzzySortSearch(search, filterInput) {
+  // use the filterInput function prop to process the input before it's sent to fuzzysort
+  // ex: strip action keys from input before searching commands, ex:
+  // "?something" or ">something" should search "something"
+  return filterInput(search);
+}
+
 // Teach Autosuggest how to calculate suggestions for any given input value.
-const getSuggestions = function (value, allCommands, options) {
+const getSuggestions = function (unfilteredSearch, allCommands, options, filterInput) {
+  
+  const search = filterFuzzySortSearch(unfilteredSearch, filterInput);
+  
   // TODO: preparing fuzzysort results make them much faster
   // however prepare is expensiveand should only be run when
   // the commands change lodash.once get close to this
@@ -37,11 +47,11 @@ const getSuggestions = function (value, allCommands, options) {
 
   // If the user specified an autosuggest term
   // search for close matches
-  const suggestionResults = fuzzysort.go(value, allCommands, options);
+  const suggestionResults = fuzzysort.go(search, allCommands, options);
 
   // if the user didnt suggest a specific term or there's a search term
   // but no matches were found return all the commands
-  if (!value || !suggestionResults.length) {
+  if (!search || !suggestionResults.length) {
     return allCommands;
   }
 

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -24,17 +24,17 @@ function formatSuggestions(filteredSuggestions) {
   });
 }
 
-function filterFuzzySortSearch(search, filterInput) {
-  // use the filterInput function prop to process the input before it's sent to fuzzysort
+function filterFuzzySortSearch(search, filterSearchQuery) {
+  // use the filterSearchQuery function prop to process the input before it's sent to fuzzysort
   // ex: strip action keys from input before searching commands, ex:
   // "?something" or ">something" should search "something"
-  return filterInput(search);
+  return filterSearchQuery(search);
 }
 
 // Teach Autosuggest how to calculate suggestions for any given input value.
-const getSuggestions = function (unfilteredSearch, allCommands, options, filterInput) {
+const getSuggestions = function (unfilteredSearch, allCommands, options, filterSearchQuery) {
   
-  const search = filterFuzzySortSearch(unfilteredSearch, filterInput);
+  const search = filterFuzzySortSearch(unfilteredSearch, filterSearchQuery);
   
   // TODO: preparing fuzzysort results make them much faster
   // however prepare is expensiveand should only be run when

--- a/src/suggestions.test.js
+++ b/src/suggestions.test.js
@@ -5,14 +5,14 @@ import fuzzysortOptions from "./fuzzysort-options";
 describe("getSuggestions", () => {
   describe("no value", () => {
     it("should return all commands", () => {
-      const commands = getSuggestions("", allCommands, fuzzysortOptions);
+      const commands = getSuggestions("", allCommands, fuzzysortOptions, inputValue => inputValue);
       expect(commands).toEqual(allCommands);
     });
   });
 
   describe("commands", () => {
     it("should permit the use custom properties", () => {
-      const commands = getSuggestions("Jump", allCommands, fuzzysortOptions);
+      const commands = getSuggestions("Jump", allCommands, fuzzysortOptions, inputValue => inputValue);
       // the command palette does not natively support an "id" property
       // however a developer may easily add any set of obj properties to each command
       // the following assertion tests that custom command properties are supported
@@ -22,7 +22,7 @@ describe("getSuggestions", () => {
 
   describe("a value was provided", () => {
     it("should return and highlight the matching commands", () => {
-      const commands = getSuggestions("Imports", allCommands, fuzzysortOptions);
+      const commands = getSuggestions("Imports", allCommands, fuzzysortOptions, inputValue => inputValue);
 
       expect(commands[0]).toMatchObject({
         name: "Stop All Data Imports",
@@ -42,7 +42,8 @@ describe("getSuggestions", () => {
       const matchName = getSuggestions(
         "Imports",
         allCommands,
-        fuzzysortOptions
+        fuzzysortOptions,
+        inputValue => inputValue
       );
       expect(matchName[0]).toMatchObject({
         name: "Stop All Data Imports",
@@ -53,7 +54,8 @@ describe("getSuggestions", () => {
       const matchCategory = getSuggestions(
         "Com",
         allCommands,
-        fuzzysortOptions
+        fuzzysortOptions,
+        inputValue => inputValue
       );
       expect(matchCategory[0]).toMatchObject({
         name: "Stop All Data Imports",


### PR DESCRIPTION
 ```filterInput``` a function that filters searched input. If this prop is not used the default behavior will search the input exactly entered otherwise whatever gets returned for each suggestion is the text that will be searched. You might use this filter out extraneous characters such as ">" or "?" like VS Code does for _action_ keys, ex:
  ```js
    <CommandPalette
      commands={commands}
      placeholder="Try typing '?st', '>st' or 'st'"
      defaultInputValue=">"
      filterSearchQuery={ inputValue => {
        // strip action keys from input before searching commands, ex:
        // "?something" or ">something" should search "something"
        return inputValue.replace(/^(>|\?)/g, '');
      }}
      open
    />