### PR TITLE
fix: Error typo version

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "react": "16 - 18",
-    "react-dom": "16 -18"
+    "react-dom": "16 - 18"
   },
   "devDependencies": {
     "@babel/cli": "^7.18.9",


### PR DESCRIPTION
Error from react and react-dom 17 compatibility

```
⚡: npm i --save react-command-palette
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: admin@undefined
npm ERR! Found: react-dom@17.0.2
npm ERR! node_modules/react-dom
npm ERR!   react-dom@"17.0.2" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react-dom@"16 -18" from react-command-palette@0.18.0
npm ERR! node_modules/react-command-palette
npm ERR!   react-command-palette@"*" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
```