### PR TITLE
Feat: Add displayTrigger boolean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ node_modules/
 
 #IDE
 .vscode
+.idea

--- a/src/__snapshots__/command-palette.test.js.snap
+++ b/src/__snapshots__/command-palette.test.js.snap
@@ -868,6 +868,9 @@ exports[`Command List renders a command 1`] = `
           />
           <div
             class="ReactModalPortal"
+          />
+          <div
+            class="ReactModalPortal"
           >
             <div
               class="ReactModal__Overlay chrome-overlay"
@@ -4004,6 +4007,9 @@ exports[`Command List renders a command 1`] = `
                   </div>
                 </div>
               </div>
+              <div
+                class="ReactModalPortal"
+              />
               <div
                 class="ReactModalPortal"
               />
@@ -7772,6 +7778,9 @@ exports[`Opening the palette displays the suggestion list 1`] = `
           />
           <div
             class="ReactModalPortal"
+          />
+          <div
+            class="ReactModalPortal"
           >
             <div
               class="ReactModal__Overlay chrome-overlay"
@@ -9407,6 +9416,9 @@ exports[`Opening the palette displays the suggestion list 1`] = `
                   </div>
                 </div>
               </div>
+              <div
+                class="ReactModalPortal"
+              />
               <div
                 class="ReactModalPortal"
               />
@@ -13421,6 +13433,9 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
           />
           <div
             class="ReactModalPortal"
+          />
+          <div
+            class="ReactModalPortal"
           >
             <div
               class="ReactModal__Overlay chrome-overlay"
@@ -15007,6 +15022,9 @@ exports[`props.reactModalParentSelector should render render reat-modal in the t
                   </div>
                 </div>
               </div>
+              <div
+                class="ReactModalPortal"
+              />
               <div
                 class="ReactModalPortal"
               />
@@ -18423,6 +18441,9 @@ exports[`props.theme should render a custom theme 1`] = `
           />
           <div
             class="ReactModalPortal"
+          />
+          <div
+            class="ReactModalPortal"
           >
             <div
               class="ReactModal__Overlay chrome-overlay"
@@ -19227,6 +19248,9 @@ exports[`props.theme should render a custom theme 1`] = `
                   </div>
                 </div>
               </div>
+              <div
+                class="ReactModalPortal"
+              />
               <div
                 class="ReactModalPortal"
               />

--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -337,7 +337,7 @@ class CommandPalette extends React.Component {
     >
       {this.renderAutoSuggest()}
     </ReactModal>
-    if(trigger) {
+    if(trigger !== null) {
       return (
         <div className="react-command-palette">
           <PaletteTrigger

--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -316,36 +316,42 @@ class CommandPalette extends React.Component {
       theme,
       reactModalParentSelector,
       shouldReturnFocusAfterClose,
+      displayTrigger
     } = this.props;
-    return (
-      <div className="react-command-palette">
-        <PaletteTrigger
-          onClick={this.handleOpenModal}
-          trigger={trigger}
-          theme={theme.trigger}
-        />
-        <ReactModal
-          appElement={document.body}
-          isOpen={showModal}
-          parentSelector={() =>
-            document.querySelector(reactModalParentSelector)
-          }
-          onAfterOpen={this.afterOpenModal}
-          onRequestClose={this.handleCloseModal}
-          shouldReturnFocusAfterClose={shouldReturnFocusAfterClose}
-          className={theme.modal}
-          overlayClassName={theme.overlay}
-          contentLabel="Command Palette"
-          closeTimeoutMS={
-            1
-            /* otherwise the modal is not closed when
-          suggestion is selected by pressing Enter */
-          }
-        >
-          {this.renderAutoSuggest()}
-        </ReactModal>
-      </div>
-    );
+    const modal = <ReactModal
+      appElement={document.body}
+      isOpen={showModal}
+      parentSelector={() =>
+        document.querySelector(reactModalParentSelector)
+      }
+      onAfterOpen={this.afterOpenModal}
+      onRequestClose={this.handleCloseModal}
+      shouldReturnFocusAfterClose={shouldReturnFocusAfterClose}
+      className={theme.modal}
+      overlayClassName={theme.overlay}
+      contentLabel="Command Palette"
+      closeTimeoutMS={
+        1
+        /* otherwise the modal is not closed when
+      suggestion is selected by pressing Enter */
+      }
+    >
+      {this.renderAutoSuggest()}
+    </ReactModal>
+    if(displayTrigger) {
+      return (
+        <div className="react-command-palette">
+          <PaletteTrigger
+            onClick={this.handleOpenModal}
+            trigger={trigger}
+            theme={theme.trigger}
+          />
+          {modal}
+        </div>
+      );
+    }
+    return modal
+    
   }
 
   renderInlineCommandPalette() {
@@ -390,6 +396,7 @@ CommandPalette.defaultProps = {
   shouldReturnFocusAfterClose: true,
   showSpinnerOnSelect: true,
   theme: defaultTheme,
+  displayTrigger: true,
 };
 
 CommandPalette.propTypes = {
@@ -443,17 +450,17 @@ CommandPalette.propTypes = {
    *  first suggestion. Defaults to false. */
   highlightFirstSuggestion: PropTypes.bool,
 
-  /** When suggestion is clicked, react-autosuggest needs to populate the input element  
+  /** When suggestion is clicked, react-autosuggest needs to populate the input element
    * based on the clicked suggestion. Teach react-autosuggest how to calculate the
-   * input value for every given suggestion. By default the highlighed suggestion will be 
+   * input value for every given suggestion. By default the highlighed suggestion will be
    * displayed */
-  getSuggestionValue: PropTypes.func, 
+  getSuggestionValue: PropTypes.func,
 
   /** options controls how fuzzy search is configured see [fuzzysort options]
    * (https://github.com/farzher/fuzzysort#options) */
   options: PropTypes.object,
 
-  /** a function that filters the search query. If this prop is not used the default 
+  /** a function that filters the search query. If this prop is not used the default
    * behavior will search the input exactly entered */
   filterSearchQuery: PropTypes.func,
 
@@ -536,6 +543,9 @@ CommandPalette.propTypes = {
   /** Styles and object that contains a list of key value pairs where the keys map the
    * command palette components to their CSS class names. */
   theme: PropTypes.object,
+  
+  /** Determines whether you want the trigger button to display while in modal mode, defaults to true */
+  displayTrigger: PropTypes.bool,
 };
 
 export default CommandPalette;

--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -316,7 +316,6 @@ class CommandPalette extends React.Component {
       theme,
       reactModalParentSelector,
       shouldReturnFocusAfterClose,
-      displayTrigger
     } = this.props;
     const modal = <ReactModal
       appElement={document.body}
@@ -338,7 +337,7 @@ class CommandPalette extends React.Component {
     >
       {this.renderAutoSuggest()}
     </ReactModal>
-    if(displayTrigger) {
+    if(trigger) {
       return (
         <div className="react-command-palette">
           <PaletteTrigger
@@ -396,7 +395,6 @@ CommandPalette.defaultProps = {
   shouldReturnFocusAfterClose: true,
   showSpinnerOnSelect: true,
   theme: defaultTheme,
-  displayTrigger: true,
 };
 
 CommandPalette.propTypes = {
@@ -500,7 +498,10 @@ CommandPalette.propTypes = {
    * clicked. If a custom trigger is not set, then by default a button will be used. If a
    * custom component or string is provided then it will automatically be wrapped inside
    * an accessible div which will allow it be keyboard accessible, clickable and focusable
-   * for assistive technologies. */
+   * for assistive technologies.
+   *
+   * Setting this to null prevents the trigger from rendering. Useful when the command palette will be opened externally.
+   * */
   trigger: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 
   /** spinner a string or a React.ComponentType that is displayed when the user selects
@@ -543,9 +544,6 @@ CommandPalette.propTypes = {
   /** Styles and object that contains a list of key value pairs where the keys map the
    * command palette components to their CSS class names. */
   theme: PropTypes.object,
-  
-  /** Determines whether you want the trigger button to display while in modal mode, defaults to true */
-  displayTrigger: PropTypes.bool,
 };
 
 export default CommandPalette;

--- a/src/command-palette.test.js
+++ b/src/command-palette.test.js
@@ -264,6 +264,16 @@ describe("props.inputFilter", () => {
   });
 });
 
+describe("props.trigger", () => {
+  it("should not render the trigger when null", () => {
+    const {container} = render(<CommandPalette commands={mockCommands} trigger={null} open />);
+    const commandPalette = container.getElementsByClassName('react-command-palette');
+    const firstSuggestion = screen.queryAllByText('Start All Data Imports')[0];
+    expect(firstSuggestion).toBeInTheDocument();
+    expect(commandPalette.length).toBe(0)
+  });
+});
+
 describe("props.theme", () => {
   it("should render a custom theme", () => {
     const commandPalette = mount(

--- a/src/index.stories.js
+++ b/src/index.stories.js
@@ -347,8 +347,8 @@ storiesOf("Command Palette", module)
       <CommandPalette commands={commands} reactModalParentSelector="#main" open />
     </div>
   ))
-  .add("with displayTrigger false", () => (
+  .add("with trigger null", () => (
     <div id="main">
-      <CommandPalette commands={commands} reactModalParentSelector="#main" displayTrigger={false} />
+      <CommandPalette commands={commands} reactModalParentSelector="#main" trigger={null} />
     </div>
   ));

--- a/src/index.stories.js
+++ b/src/index.stories.js
@@ -133,13 +133,13 @@ storiesOf("Command Palette", module)
       }
     }
   )
-  .add("is toggled open", () => 
+  .add("is toggled open", () =>
     {
     const open = boolean("Open", true);
     return <CommandPalette commands={commands} open={open} />
     }, {
     info: {
-      text: `Adding an _open_ prop will force the command palette to be displayed 
+      text: `Adding an _open_ prop will force the command palette to be displayed
       when it mounts. By default command palette will be hidden until the _trigger_
       is cliked.`
     }
@@ -223,12 +223,12 @@ storiesOf("Command Palette", module)
     () => <CommandPalette commands={commands} trigger="Click Me!" />,
     {
       info: {
-        text: `Use the _trigger_ prop to customize the component that the user 
+        text: `Use the _trigger_ prop to customize the component that the user
         will click to open the command palette. The property accepts either a
-        string or a React component. Note that component will be wrapped with a 
+        string or a React component. Note that component will be wrapped with a
         _div_ that behaves like a button. So there is no need to add any events.
         This component will also be focusable and may be activated via keyboard
-        to maintain accessibility. If a trigger is not specified then the a 
+        to maintain accessibility. If a trigger is not specified then the a
         default command palette will be used.
         `
       }
@@ -345,5 +345,10 @@ storiesOf("Command Palette", module)
   .add("with reactModalParentSelector", () => (
     <div id="main">
       <CommandPalette commands={commands} reactModalParentSelector="#main" open />
+    </div>
+  ))
+  .add("with displayTrigger false", () => (
+    <div id="main">
+      <CommandPalette commands={commands} reactModalParentSelector="#main" displayTrigger={false} />
     </div>
   ));

--- a/src/index.stories.js
+++ b/src/index.stories.js
@@ -349,6 +349,6 @@ storiesOf("Command Palette", module)
   ))
   .add("with trigger null", () => (
     <div id="main">
-      <CommandPalette commands={commands} reactModalParentSelector="#main" trigger={null} />
+      <CommandPalette commands={commands} reactModalParentSelector="#main" trigger={null} open />
     </div>
   ));


### PR DESCRIPTION
Add `null` option to `props.trigger`, so that the trigger won't render. ex:
```
<div id="main">
      <CommandPalette commands={commands} reactModalParentSelector="#main" trigger={null} open />
</div>   
```