### PR TITLE
Updates to allow node 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "git+https://github.com/asabaylus/react-command-palette.git"
   },
   "engines": {
-    "node": ">=16 <=18"
+    "node": ">=16"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
I'm currently running this without problem using --ignore-engines flag within my project. I don't think this locking down of specific engines is necessary.